### PR TITLE
refactor: 백엔드 로그 유틸 공통화

### DIFF
--- a/dashboard/server/server.js
+++ b/dashboard/server/server.js
@@ -5,6 +5,7 @@ const { config } = require("./src/config");
 const { initWebSocket } = require("./src/realtime/websocket");
 const { setBroadcaster } = require("./src/domains/mock-lidar/mockLidar.service");
 const { startLidarSimulator } = require("./src/simulator/lidarSimulator");
+const { logger } = require("./src/utils/logger");
 
 const server = http.createServer(app);
 const { broadcast } = initWebSocket(server);
@@ -13,8 +14,10 @@ setBroadcaster(broadcast);
 startLidarSimulator();
 
 server.listen(config.port, "0.0.0.0", () => {
-  console.log(`Server started and listening on port ${config.port}`);
-  console.log(`REST  ${config.dashboardBaseUrl}/api/state`);
-  console.log(`WS    ${config.dashboardBaseUrl.replace(/^http/, "ws")}`);
-  console.log(`Detector proxy ${config.detectorBaseUrl}`);
+  logger.info("server started", {
+    port: config.port,
+    restUrl: `${config.dashboardBaseUrl}/api/state`,
+    wsUrl: config.dashboardBaseUrl.replace(/^http/, "ws"),
+    detectorBaseUrl: config.detectorBaseUrl,
+  });
 });

--- a/dashboard/server/src/domains/demo/demo.controller.js
+++ b/dashboard/server/src/domains/demo/demo.controller.js
@@ -1,4 +1,5 @@
 const { config } = require("../../config");
+const { logger } = require("../../utils/logger");
 const mockLidarService = require("../mock-lidar/mockLidar.service");
 
 async function startDemo(req, res) {
@@ -15,7 +16,7 @@ async function startDemo(req, res) {
     mockLidarService.pushLog("Detector demo started");
     res.json({ ok: true, detector: data });
   } catch (err) {
-    console.error("[demo/start]", err);
+    logger.error("detector demo start failed", { err });
     mockLidarService.pushLog(`Demo START failed: ${String(err.message || err)}`);
     res.status(500).json({ ok: false, error: String(err.message || err) });
   }
@@ -37,7 +38,7 @@ async function resetDemo(req, res) {
 
     res.json({ ok: true, detector: data });
   } catch (err) {
-    console.error("[demo/reset]", err);
+    logger.error("detector demo reset failed", { err });
     mockLidarService.pushLog(`Demo RESET failed: ${String(err.message || err)}`);
     res.status(500).json({ ok: false, error: String(err.message || err) });
   }

--- a/dashboard/server/src/domains/mock-lidar/mockLidar.service.js
+++ b/dashboard/server/src/domains/mock-lidar/mockLidar.service.js
@@ -1,4 +1,5 @@
 const { nowTime } = require("../../utils/time");
+const { logger } = require("../../utils/logger");
 
 let broadcast = () => {};
 
@@ -59,7 +60,7 @@ function clamp(n, min, max) {
 
 function openGate() {
   state.gate = "OPENED";
-  console.log("[MOCK] BARRIER: OPEN");
+  logger.info("mock barrier opened");
   pushLog("Barrier OPEN requested");
   broadcast("state", state);
   return state.gate;
@@ -67,7 +68,7 @@ function openGate() {
 
 function closeGate() {
   state.gate = "CLOSED";
-  console.log("[MOCK] BARRIER: CLOSE");
+  logger.info("mock barrier closed");
   pushLog("Barrier CLOSE requested");
   broadcast("state", state);
   return state.gate;
@@ -76,7 +77,7 @@ function closeGate() {
 function setVmsText(text) {
   const safeText = String(text ?? "").slice(0, 80);
   state.vmsLast = safeText;
-  console.log(`[MOCK] VMS TEXT: ${safeText}`);
+  logger.info("mock vms text requested", { text: safeText });
   pushLog(`VMS requested: ${safeText || "(empty)"}`);
   broadcast("state", state);
   return state.vmsLast;

--- a/dashboard/server/src/domains/wrongway/wrongway.controller.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.controller.js
@@ -1,9 +1,19 @@
 const { nowTime } = require("../../utils/time");
+const { logger } = require("../../utils/logger");
 const mockLidarService = require("../mock-lidar/mockLidar.service");
 
 function receiveWrongWay(req, res) {
   const body = req.body || {};
-  console.log("[wrongway hit]", new Date().toISOString(), body);
+  logger.info("wrongway payload received", {
+    id: body.id,
+    stage: body.stage,
+    zoneId: body.zone_id,
+    trackId: body.track_id,
+  });
+  logger.debug("wrongway payload shape received", {
+    payloadKeys: Object.keys(body),
+    payloadSize: JSON.stringify(body).length,
+  });
 
   const alert = {
     id: body.id || `evt-${Date.now()}`,
@@ -27,7 +37,11 @@ function receiveWrongWay(req, res) {
     snapshot: body.snapshot,
   };
 
-  console.log("[broadcast alert]", alert);
+  logger.info("wrongway alert broadcast", {
+    id: alert.id,
+    stage: alert.stage,
+    subMessage: alert.subMessage,
+  });
 
   mockLidarService.applyAlertEffects(alert);
   mockLidarService.addWrongWayHistory(alert);

--- a/dashboard/server/src/utils/logger.js
+++ b/dashboard/server/src/utils/logger.js
@@ -1,0 +1,68 @@
+const LEVEL_PRIORITY = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const currentLevel = String(process.env.LOG_LEVEL || "info").toLowerCase();
+const minimumPriority = LEVEL_PRIORITY[currentLevel] || LEVEL_PRIORITY.info;
+
+function normalizeMeta(meta) {
+  if (!meta || typeof meta !== "object") return {};
+
+  // meta는 logger 호출 시 함께 넘긴 추가 정보다.
+  // 그대로 출력하기 어려운 값은 logMeta에 로그용 형태로 정리해서 담는다.
+  const logMeta = {};
+
+  for (const [key, value] of Object.entries(meta)) {
+    // Error 객체는 JSON 변환 시 내용이 빠질 수 있어 필요한 값만 직접 꺼낸다.
+    if (value instanceof Error) {
+      logMeta[key] = {
+        name: value.name,
+        message: value.message,
+        stack: value.stack,
+      };
+      continue;
+    }
+
+    logMeta[key] = value;
+  }
+
+  return logMeta;
+}
+
+function write(level, message, meta) {
+  // LOG_LEVEL보다 낮은 중요도의 로그는 출력하지 않는다.
+  if (LEVEL_PRIORITY[level] < minimumPriority) return;
+
+  const entry = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...normalizeMeta(meta),
+  };
+
+  const output = JSON.stringify(entry);
+  if (level === "error") {
+    console.error(output);
+    return;
+  }
+
+  if (level === "warn") {
+    console.warn(output);
+    return;
+  }
+
+  console.log(output);
+}
+
+// 서버 운영 로그를 한 곳에서 관리한다. 화면 표시용 이벤트 로그는 pushLog를 사용한다.
+const logger = {
+  debug: (message, meta) => write("debug", message, meta),
+  info: (message, meta) => write("info", message, meta),
+  warn: (message, meta) => write("warn", message, meta),
+  error: (message, meta) => write("error", message, meta),
+};
+
+module.exports = { logger };


### PR DESCRIPTION
## 작업 내용

- 백엔드 공통 logger 유틸 추가
- 기존 `console.log`, `console.error` 사용부를 `logger.info`, `logger.error`로 변경
- 로그 레벨(`debug`, `info`, `warn`, `error`) 기반 출력 구조 추가
- `LOG_LEVEL` 환경변수로 로그 출력 범위 제어 가능하도록 정리
- `Error` 객체 로그 출력 시 `name`, `message`, `stack`이 남도록 처리
- 역주행 수신 payload는 원문 전체 대신 key 목록과 크기만 debug 로그로 기록

## 변경 파일

- `dashboard/server/src/utils/logger.js`
- `dashboard/server/server.js`
- `dashboard/server/src/domains/demo/demo.controller.js`
- `dashboard/server/src/domains/mock-lidar/mockLidar.service.js`
- `dashboard/server/src/domains/wrongway/wrongway.controller.js`

## 검증

- `npm run check:server` 통과

## 참고

- 화면에 표시되는 이벤트 로그는 기존처럼 `pushLog`를 사용
- 서버 운영/디버깅용 로그만 `logger`로 분리