### PR TITLE
Codex/control board protocol

### DIFF
--- a/dashboard/server/src/domains/external-ingest/adapters/controlBoardPacket.adapter.js
+++ b/dashboard/server/src/domains/external-ingest/adapters/controlBoardPacket.adapter.js
@@ -4,34 +4,44 @@ const {
   createExternalEvent,
   createRawSummary,
 } = require("../externalEvent.model");
+const { parseControlBoardPacket } = require("../protocol/controlBoardProtocol");
 
 // command 값은 제어보드 신호 의미를 내부 이벤트 종류와 경고 단계로 매핑한다.
 const COMMAND_EVENT_MAP = {
-  STAGE_1: { eventType: EXTERNAL_EVENT_TYPE.CONTROL_STAGE, stage: 1, message: "통합 제어보드 1차 경고 수신" },
-  STAGE_2: { eventType: EXTERNAL_EVENT_TYPE.CONTROL_STAGE, stage: 2, message: "통합 제어보드 2차 경고 수신" },
-  CLEAR: { eventType: EXTERNAL_EVENT_TYPE.SITUATION_CLEARED, stage: 0, message: "통합 제어보드 상황 해제 수신" },
+  STAGE_1_ON: { eventType: EXTERNAL_EVENT_TYPE.CONTROL_STAGE, stage: 1, message: "통합 제어보드 1차 경고 시작" },
+  STAGE_2_ON: { eventType: EXTERNAL_EVENT_TYPE.CONTROL_STAGE, stage: 2, message: "통합 제어보드 2차 경고 시작" },
+  STAGE_2_RETURN: { eventType: EXTERNAL_EVENT_TYPE.SITUATION_CLEARED, stage: 2, message: "통합 제어보드 2차 복귀/해제" },
+  SYSTEM_RESET: { eventType: EXTERNAL_EVENT_TYPE.SITUATION_CLEARED, stage: 0, message: "통합 제어보드 전체 시스템 리셋" },
+  UNKNOWN: { eventType: EXTERNAL_EVENT_TYPE.UNKNOWN, stage: 0, message: "통합 제어보드 패킷 수신" },
 };
 
-// packet이 문자열이든 바이트 배열이든 현장 확인용 크기를 계산한다.
-function getPacketSize(packet) {
-  if (Array.isArray(packet)) return packet.length;
-  if (typeof packet === "string") return packet.length;
-  return 0;
+function getFallbackCommand(payload) {
+  // packet이 아직 없거나 파싱할 수 없을 때는 Swagger 테스트용 command 값을 사용한다.
+  return String(payload.command || payload.commandCode || "UNKNOWN").toUpperCase();
 }
 
-// 통합 제어보드 packet/mock payload를 내부 표준 이벤트로 바꾸는 adapter 함수다.
-function adaptControlBoardPacket(payload = {}, options = {}) {
-  // 통합 제어보드는 실제 현장에서 RS-485 패킷으로 신호를 줄 가능성이 높다.
-  // 지금 단계에서는 HTTP mock API로 packet/command/crcValid 값을 받아 adapter 흐름만 먼저 검증한다.
-  // 실제 CRC-8 계산과 바이트 위치 해석은 protocol adapter 단계에서 PDF 규격 기준으로 구현한다.
-  const command = String(payload.command || payload.commandCode || "UNKNOWN").toUpperCase();
-  const mapped = COMMAND_EVENT_MAP[command] || {
-    eventType: EXTERNAL_EVENT_TYPE.UNKNOWN,
-    stage: payload.stage,
-    message: "통합 제어보드 패킷 수신",
-  };
+function getParsedCommand(payload, packetResult) {
+  // 실제 패킷에서 해석한 command를 우선 사용한다.
+  // packet 해석이 UNKNOWN이면 기존 mock command 값을 fallback으로 사용해 테스트 편의성을 유지한다.
+  if (packetResult?.command && packetResult.command !== "UNKNOWN") return packetResult.command;
+  return getFallbackCommand(payload);
+}
 
-  const crcStatus = payload.crcValid === true ? "VALID" : payload.crcValid === false ? "INVALID" : "NOT_VERIFIED";
+function getCrcStatus(payload, packetResult) {
+  // packet이 있으면 실제 CRC 계산 결과를 우선 사용한다.
+  // packet이 없으면 기존 mock 테스트용 crcValid 값을 사용한다.
+  if (packetResult?.crcStatus) return packetResult.crcStatus;
+  return payload.crcValid === true ? "VALID" : payload.crcValid === false ? "INVALID" : "NOT_VERIFIED";
+}
+
+function adaptControlBoardPacket(payload = {}, options = {}) {
+  // 통합 제어보드는 실제 현장에서 RS-485 10바이트 패킷으로 신호를 줄 가능성이 높다.
+  // 이 adapter는 HTTP mock으로 받은 packet도 실제 패킷과 같은 방식으로 파싱해서 내부 이벤트로 바꾼다.
+  // packet이 없으면 기존 command/crcValid 기반 mock 흐름을 유지해 Swagger 테스트를 계속 사용할 수 있다.
+  const packetResult = payload.packet ? parseControlBoardPacket(payload.packet) : null;
+  const command = getParsedCommand(payload, packetResult);
+  const mapped = COMMAND_EVENT_MAP[command] || COMMAND_EVENT_MAP.UNKNOWN;
+  const crcStatus = getCrcStatus(payload, packetResult);
 
   return createExternalEvent({
     id: payload.id || payload.event_id,
@@ -48,7 +58,13 @@ function adaptControlBoardPacket(payload = {}, options = {}) {
       ...createRawSummary(payload),
       command,
       crcStatus,
-      packetSize: getPacketSize(payload.packet),
+      packetSize: packetResult?.packetSize || 0,
+      packetBytes: packetResult?.hex || [],
+      crcExpected: packetResult?.crcExpected ?? null,
+      crcCalculated: packetResult?.crcCalculated ?? null,
+      packetValid: packetResult?.isValid ?? crcStatus === "VALID",
+      packetErrors: packetResult?.errors || [],
+      parsed: packetResult?.parsed || null,
     },
   });
 }

--- a/dashboard/server/src/domains/external-ingest/externalIngest.controller.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.controller.js
@@ -1,5 +1,11 @@
 const externalIngestService = require("./externalIngest.service");
 
+// 실제 라이다 PC HTTP 요청을 받아 service로 넘기고 수신 결과를 응답한다.
+function receiveLidar(req, res) {
+  const event = externalIngestService.ingestLidarLive(req.body || {});
+  res.json({ ok: true, eventId: event.id, receivedAt: event.receivedAt, event });
+}
+
 // 라이다 mock HTTP 요청을 받아 service로 넘기고 수신 결과를 응답한다.
 function receiveLidarMock(req, res) {
   // controller는 HTTP 요청/응답만 담당하고, 실제 변환과 화면 반영은 service에 맡긴다.
@@ -29,6 +35,7 @@ function getRecentEvents(req, res) {
 }
 
 module.exports = {
+  receiveLidar,
   receiveLidarMock,
   receiveControlBoardMock,
   testControlBoardSerial,

--- a/dashboard/server/src/domains/external-ingest/externalIngest.controller.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.controller.js
@@ -13,6 +13,13 @@ function receiveLidarMock(req, res) {
   res.json({ ok: true, eventId: event.id, receivedAt: event.receivedAt, event });
 }
 
+// 통합 제어보드 실제 HTTP ingest 요청을 받아 service로 넘긴다.
+function receiveControlBoard(req, res) {
+  // RS-485 장비가 직접 HTTP를 호출하지 않더라도, 브릿지/테스트 프로그램이 같은 진입점을 사용할 수 있게 둔다.
+  const event = externalIngestService.ingestControlBoardLive(req.body || {});
+  res.json({ ok: true, eventId: event.id, receivedAt: event.receivedAt, event });
+}
+
 // 통합 제어보드 mock packet 요청을 받아 service로 넘기고 수신 결과를 응답한다.
 function receiveControlBoardMock(req, res) {
   // 통합 제어보드 mock 요청도 service로 넘겨 내부 이벤트 변환 흐름을 동일하게 탄다.
@@ -37,6 +44,7 @@ function getRecentEvents(req, res) {
 module.exports = {
   receiveLidar,
   receiveLidarMock,
+  receiveControlBoard,
   receiveControlBoardMock,
   testControlBoardSerial,
   getRecentEvents,

--- a/dashboard/server/src/domains/external-ingest/externalIngest.routes.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.routes.js
@@ -5,6 +5,7 @@ const controller = require("./externalIngest.controller");
 const router = express.Router();
 
 // 외부 장비 연동 전까지 Swagger/curl로 수신 흐름을 검증하기 위한 ingest API 묶음이다.
+router.post("/ingest/lidar", controller.receiveLidar);
 router.post("/ingest/lidar/mock", controller.receiveLidarMock);
 router.post("/ingest/control-board/mock", controller.receiveControlBoardMock);
 router.post("/ingest/control-board/serial/test", controller.testControlBoardSerial);

--- a/dashboard/server/src/domains/external-ingest/externalIngest.routes.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.routes.js
@@ -7,6 +7,7 @@ const router = express.Router();
 // 외부 장비 연동 전까지 Swagger/curl로 수신 흐름을 검증하기 위한 ingest API 묶음이다.
 router.post("/ingest/lidar", controller.receiveLidar);
 router.post("/ingest/lidar/mock", controller.receiveLidarMock);
+router.post("/ingest/control-board", controller.receiveControlBoard);
 router.post("/ingest/control-board/mock", controller.receiveControlBoardMock);
 router.post("/ingest/control-board/serial/test", controller.testControlBoardSerial);
 router.get("/ingest/events/recent", controller.getRecentEvents);

--- a/dashboard/server/src/domains/external-ingest/externalIngest.service.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.service.js
@@ -110,6 +110,25 @@ function ingestControlBoardMock(payload) {
   return event;
 }
 
+// 통합 제어보드 실제 HTTP 수신을 처리하는 service 진입점이다.
+function ingestControlBoardLive(payload) {
+  // 현장에서는 RS-485 직접 연결, HTTP 브릿지, 테스트 프로그램 중 어떤 방식이 될지 아직 확정되지 않았다.
+  // 그래서 실제 수신용 URL은 먼저 열어두고, 내부 처리는 mock과 같은 parser/adapter 흐름을 재사용한다.
+  const event = adaptControlBoardPacket(payload);
+
+  logger.info("external control board packet received", {
+    id: event.id,
+    mode: "LIVE",
+    command: event.rawSummary.command,
+    crcStatus: event.rawSummary.crcStatus,
+    packetValid: event.rawSummary.packetValid,
+  });
+
+  rememberEvent(event);
+  applyDashboardEffects(event);
+  return event;
+}
+
 // 실제 COM 포트를 열기 전, serial reader 입력 형태만 검증하는 테스트 진입점이다.
 function createSerialTest(payload = {}) {
   // serial reader 테스트는 아직 COM 포트를 열지 않는다.
@@ -152,6 +171,7 @@ function getRecentEvents(limit = 20) {
 module.exports = {
   ingestLidarLive,
   ingestLidarMock,
+  ingestControlBoardLive,
   ingestControlBoardMock,
   createSerialTest,
   getRecentEvents,

--- a/dashboard/server/src/domains/external-ingest/externalIngest.service.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.service.js
@@ -59,12 +59,14 @@ function applyDashboardEffects(event) {
   mockLidarService.pushLog(`[INGEST] ${event.message}`);
 }
 
-// 라이다 PC mock JSON 수신을 처리하는 service 진입점이다.
-function ingestLidarMock(payload) {
-  // 라이다 mock API의 핵심 흐름: 외부 JSON payload -> lidar adapter -> 내부 이벤트 -> 화면 반영.
+// 실제 라이다 PC와 mock 라이다 테스트 API가 같은 변환/화면 반영 흐름을 타도록 공통 처리한다.
+function ingestLidar(payload, options = {}) {
   const event = adaptLidarHttpPayload(payload);
+  const mode = options.mode || "LIVE";
+
   logger.info("external lidar ingest received", {
     id: event.id,
+    mode,
     zoneId: event.zoneId,
     deviceId: event.deviceId,
   });
@@ -72,6 +74,16 @@ function ingestLidarMock(payload) {
   rememberEvent(event);
   applyDashboardEffects(event);
   return event;
+}
+
+// 실제 라이다 PC가 현장에서 호출할 HTTP/JSON 수신 진입점이다.
+function ingestLidarLive(payload) {
+  return ingestLidar(payload, { mode: "LIVE" });
+}
+
+// 개발자와 Swagger/curl 테스트에서 사용할 라이다 mock 수신 진입점이다.
+function ingestLidarMock(payload) {
+  return ingestLidar(payload, { mode: "MOCK" });
 }
 
 // 통합 제어보드 mock 패킷 수신을 처리하는 service 진입점이다.
@@ -130,6 +142,7 @@ function getRecentEvents(limit = 20) {
 }
 
 module.exports = {
+  ingestLidarLive,
   ingestLidarMock,
   ingestControlBoardMock,
   createSerialTest,

--- a/dashboard/server/src/domains/external-ingest/externalIngest.service.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.service.js
@@ -47,6 +47,13 @@ function toDashboardEvent(event) {
 function applyDashboardEffects(event) {
   // 외부 이벤트가 들어오면 기존 mockLidarService를 통해 화면 상태, 이력, WebSocket 알림을 갱신한다.
   // 상황 해제 이벤트는 신규 역주행 건수로 세지 않기 위해 로그만 남긴다.
+  // 통합 제어보드 패킷의 CRC나 프레임 구조가 잘못된 경우에는 화면 이벤트로 전파하지 않는다.
+  // 대신 recentEvents/rawPayload/rawSummary에는 남겨서 현장에서 어떤 패킷이 들어왔는지 확인할 수 있게 한다.
+  if (event.rawSummary?.crcStatus === "INVALID" || event.rawSummary?.packetValid === false) {
+    mockLidarService.pushLog(`[INGEST:INVALID] ${event.message}`);
+    return;
+  }
+
   if (event.eventType === EXTERNAL_EVENT_TYPE.SITUATION_CLEARED) {
     mockLidarService.pushLog(`[INGEST] ${event.message}`);
     return;
@@ -95,6 +102,7 @@ function ingestControlBoardMock(payload) {
     id: event.id,
     command: event.rawSummary.command,
     crcStatus: event.rawSummary.crcStatus,
+    packetValid: event.rawSummary.packetValid,
   });
 
   rememberEvent(event);

--- a/dashboard/server/src/domains/external-ingest/protocol/controlBoardProtocol.js
+++ b/dashboard/server/src/domains/external-ingest/protocol/controlBoardProtocol.js
@@ -1,0 +1,219 @@
+const PACKET_LENGTH = 10;
+
+// PDF 기준 통합 제어보드 패킷은 항상 10바이트 고정이다.
+// Byte 0: STX, Byte 1: ID, Byte 2: TYPE, Byte 3: MODE, Byte 4: STATUS,
+// Byte 5: SELECT, Byte 6: RESERVED, Byte 7: CRC, Byte 8: ETX, Byte 9: EOF(CR)
+const STX = 0x02;
+const DEVICE_ID = 0xa1;
+const ETX = 0x03;
+const EOF = 0x0d;
+
+// TYPE은 패킷이 PC/백엔드에서 보낸 명령인지, 보드가 돌려준 응답 로그인지 구분한다.
+const TYPE_LABEL = {
+  0x10: "COMMAND",
+  0x20: "RESPONSE_LOG",
+};
+
+// MODE는 역주행 경고 단계를 표현한다. 화면에서는 stage 값으로 다시 매핑된다.
+const MODE_LABEL = {
+  0x00: "WAIT",
+  0x01: "STAGE_1",
+  0x02: "STAGE_2",
+};
+
+// STATUS는 장비 동작 상태를 표현한다. 0x02는 차단기 복귀/상승 상황으로 해석한다.
+const STATUS_LABEL = {
+  0x00: "OFF",
+  0x01: "ON",
+  0x02: "BARRIER_RETURN",
+};
+
+// SELECT는 어떤 설비 묶음을 제어하는지 나타낸다. 현재는 진단 정보로만 보관한다.
+const SELECT_LABEL = {
+  0x01: "ALL",
+  0x02: "WARNING_SET",
+  0x03: "SAFETY_SET",
+  0x10: "LED_ONLY",
+  0x11: "SPEAKER_ONLY",
+  0x12: "BARRIER_ONLY",
+};
+
+function toHex(byte) {
+  return `0x${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+}
+
+function parseByteToken(token) {
+  const normalized = String(token).trim();
+  if (!normalized) return null;
+
+  // "A1"과 "0xA1"을 모두 허용한다. Swagger/curl에서 입력 방식이 섞일 수 있기 때문이다.
+  const value = normalized.toLowerCase().startsWith("0x")
+    ? Number.parseInt(normalized.slice(2), 16)
+    : Number.parseInt(normalized, 16);
+
+  if (!Number.isInteger(value) || value < 0 || value > 0xff) return null;
+  return value;
+}
+
+function normalizePacket(packet) {
+  // RS-485 serial reader가 붙기 전에는 HTTP mock API로 패킷을 테스트한다.
+  // 그래서 "02 A1 10 ..." 같은 HEX 문자열과 [2, 161, ...] 바이트 배열을 모두 같은 배열로 정규화한다.
+  if (Array.isArray(packet)) {
+    const bytes = packet.map((value) => {
+      if (typeof value === "number") return value;
+      return parseByteToken(value);
+    });
+
+    if (bytes.some((value) => !Number.isInteger(value) || value < 0 || value > 0xff)) {
+      return { ok: false, error: "패킷 배열에는 0~255 범위의 바이트 값만 사용할 수 있습니다.", bytes: [] };
+    }
+
+    return { ok: true, bytes };
+  }
+
+  if (typeof packet === "string") {
+    const trimmed = packet.trim();
+    if (!trimmed) return { ok: false, error: "패킷 문자열이 비어 있습니다.", bytes: [] };
+
+    // 공백/콤마로 구분된 입력과 "02A110..."처럼 붙어 있는 입력을 모두 지원한다.
+    const tokens = trimmed.includes(" ") || trimmed.includes(",")
+      ? trimmed.split(/[\s,]+/).filter(Boolean)
+      : trimmed.match(/.{1,2}/g) || [];
+
+    const bytes = tokens.map(parseByteToken);
+    if (bytes.some((value) => value === null)) {
+      return { ok: false, error: "패킷 문자열에는 HEX 바이트만 사용할 수 있습니다.", bytes: [] };
+    }
+
+    return { ok: true, bytes };
+  }
+
+  return { ok: false, error: "packet은 HEX 문자열 또는 바이트 배열이어야 합니다.", bytes: [] };
+}
+
+function calculateCrc8Smbus(dataBytes) {
+  // CRC 계산 범위는 PDF 기준 Byte 1~6, 즉 ID부터 RESERVED까지다.
+  // STX(0x02), CRC Byte, ETX(0x03), EOF(0x0D)는 계산에 포함하지 않는다.
+  // PDF에는 LSB-First라고 적혀 있지만, 문서의 테스트 벡터는 표준 CRC-8/SMBUS(MSB-first) 결과와 일치한다.
+  // 따라서 안전하게 문서의 기대 CRC 값을 정답으로 보고 poly 0x07, init 0x00 방식으로 구현한다.
+  let crc = 0x00;
+
+  for (const byte of dataBytes) {
+    // 각 바이트를 현재 CRC에 XOR한 뒤 8비트씩 밀면서 다항식 0x07을 적용한다.
+    crc ^= byte;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 0x80) !== 0
+        ? ((crc << 1) ^ 0x07) & 0xff
+        : (crc << 1) & 0xff;
+    }
+  }
+
+  return crc;
+}
+
+function getProtocolCommand(parsed) {
+  // PDF의 시나리오 4개를 command로 그대로 분리한다.
+  // 나중에 프로토콜이 바뀌어도 이 함수만 보면 어떤 MODE/STATUS 조합을 어떤 상황으로 보는지 추적하기 쉽다.
+  if (parsed.mode === "STAGE_1" && parsed.status === "ON") return "STAGE_1_ON";
+  if (parsed.mode === "STAGE_2" && parsed.status === "ON") return "STAGE_2_ON";
+  if (parsed.mode === "STAGE_2" && parsed.status === "BARRIER_RETURN") return "STAGE_2_RETURN";
+  if (parsed.mode === "WAIT" && parsed.status === "OFF") return "SYSTEM_RESET";
+  return "UNKNOWN";
+}
+
+function parseControlBoardPacket(packet) {
+  // 이 함수는 외부에서 들어온 packet 하나를 검증 가능한 진단 객체로 바꾼다.
+  // adapter는 이 결과를 rawSummary에 넣어 Swagger/최근 이벤트 조회에서 확인할 수 있게 한다.
+  const normalized = normalizePacket(packet);
+  if (!normalized.ok) {
+    return {
+      isValid: false,
+      error: normalized.error,
+      bytes: normalized.bytes,
+      packetSize: normalized.bytes.length,
+      crcStatus: "NOT_VERIFIED",
+    };
+  }
+
+  const bytes = normalized.bytes;
+  const errors = [];
+
+  // 프레임 구조 검증: 길이와 시작/종료 제어 문자가 맞아야 실제 제어보드 패킷으로 볼 수 있다.
+  if (bytes.length !== PACKET_LENGTH) errors.push(`패킷 길이는 ${PACKET_LENGTH}바이트여야 합니다.`);
+  if (bytes[0] !== STX) errors.push("STX 값이 0x02가 아닙니다.");
+  if (bytes[1] !== DEVICE_ID) errors.push("장비 ID 값이 0xA1이 아닙니다.");
+  if (bytes[8] !== ETX) errors.push("ETX 값이 0x03이 아닙니다.");
+  if (bytes[9] !== EOF) errors.push("EOF 값이 0x0D가 아닙니다.");
+
+  // CRC 검증: Byte 1~6만 잘라 계산하고, 패킷의 Byte 7과 비교한다.
+  // Byte 1~6은 실제 데이터 영역이다.
+  // 순서대로 ID, TYPE, MODE, STATUS, SELECT, RESERVED이며 이 6바이트만 CRC 계산에 사용한다.
+  const dataArea = bytes.slice(1, 7);
+
+  // Byte 7은 송신 측이 계산해서 넣어준 CRC 값이다.
+  // 우리가 Byte 1~6으로 다시 계산한 값과 같아야 패킷이 전송 중 깨지지 않았다고 볼 수 있다.
+  const expectedCrc = bytes[7];
+  const calculatedCrc = dataArea.length === 6 ? calculateCrc8Smbus(dataArea) : null;
+  const crcValid = calculatedCrc !== null && expectedCrc === calculatedCrc;
+
+  if (!crcValid) errors.push("CRC-8 검증에 실패했습니다.");
+
+  // 사람이 보기 쉬운 HEX 코드와 라벨을 함께 만든다. 이 값들은 현장 디버깅용 rawSummary에 들어간다.
+  const parsed = {
+    // Byte 0: 패킷 시작 표시. 항상 0x02여야 한다.
+    stx: toHex(bytes[0] ?? 0),
+
+    // Byte 1: 장비 식별 ID. PDF에서는 통합 제어보드 ID를 0xA1로 고정한다.
+    id: toHex(bytes[1] ?? 0),
+
+    // Byte 2: 패킷 종류. 0x10은 명령, 0x20은 보드 응답/로그다.
+    typeCode: toHex(bytes[2] ?? 0),
+    type: TYPE_LABEL[bytes[2]] || "UNKNOWN",
+
+    // Byte 3: 경고 단계. 0x00 대기, 0x01 1차 경고, 0x02 2차 경고다.
+    modeCode: toHex(bytes[3] ?? 0),
+    mode: MODE_LABEL[bytes[3]] || "UNKNOWN",
+
+    // Byte 4: 동작 상태. 0x00 OFF, 0x01 ON, 0x02 차단기 복귀/상승이다.
+    statusCode: toHex(bytes[4] ?? 0),
+    status: STATUS_LABEL[bytes[4]] || "UNKNOWN",
+
+    // Byte 5: 제어 대상. 전체/경보 세트/안전 세트/개별 장비를 구분한다.
+    selectCode: toHex(bytes[5] ?? 0),
+    select: SELECT_LABEL[bytes[5]] || "UNKNOWN",
+
+    // Byte 6: 예약 필드. 현재는 0x00으로 두고 추후 확장에 사용한다.
+    reserved: toHex(bytes[6] ?? 0),
+
+    // Byte 7: 송신 측 CRC 값. calculatedCrc와 비교해 무결성을 판단한다.
+    crc: toHex(bytes[7] ?? 0),
+
+    // Byte 8: 패킷 종료 표시. 항상 0x03이어야 한다.
+    etx: toHex(bytes[8] ?? 0),
+
+    // Byte 9: 최종 종료 확인 값(CR). 항상 0x0D여야 한다.
+    eof: toHex(bytes[9] ?? 0),
+  };
+
+  const command = getProtocolCommand(parsed);
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    bytes,
+    hex: bytes.map(toHex),
+    packetSize: bytes.length,
+    command,
+    parsed,
+    dataArea: dataArea.map(toHex),
+    crcExpected: expectedCrc,
+    crcCalculated: calculatedCrc,
+    crcStatus: crcValid ? "VALID" : "INVALID",
+  };
+}
+
+module.exports = {
+  calculateCrc8Smbus,
+  parseControlBoardPacket,
+};

--- a/dashboard/server/src/swagger.js
+++ b/dashboard/server/src/swagger.js
@@ -201,6 +201,32 @@ const swaggerSpec = {
         },
       },
     },
+    "/api/ingest/control-board": {
+      post: {
+        tags: ["External Ingest"],
+        summary: "통합 제어보드 실제 HTTP 패킷 수신",
+        description:
+          "통합 제어보드 또는 중간 브릿지 프로그램이 실제 패킷을 HTTP JSON으로 넘길 때 사용하는 API입니다. RS-485 직접 연결이 확정되기 전까지 실제 수신 진입점으로 유지하고, 내부에서는 mock과 같은 parser/adapter 흐름을 사용합니다.",
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ControlBoardMockRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "통합 제어보드 실제 패킷 수신 완료",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ExternalIngestResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/api/ingest/control-board/mock": {
       post: {
         tags: ["External Ingest"],

--- a/dashboard/server/src/swagger.js
+++ b/dashboard/server/src/swagger.js
@@ -151,11 +151,36 @@ const swaggerSpec = {
         },
       },
     },
+    "/api/ingest/lidar": {
+      post: {
+        tags: ["External Ingest"],
+        summary: "라이다 PC 실제 HTTP 이벤트 수신",
+        description: "현장 라이다 PC가 실제 역주행 감지 JSON을 전송할 때 사용하는 API입니다. 수신된 원본 데이터는 현장 연동 확인을 위해 rawPayload로 함께 반환됩니다.",
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/LidarIngestRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "라이다 실제 이벤트 수신 완료",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ExternalIngestResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/api/ingest/lidar/mock": {
       post: {
         tags: ["External Ingest"],
         summary: "라이다 PC mock HTTP 이벤트 수신",
-        description: "실제 라이다 PC 데이터 규격 확정 전, JSON 수신 흐름을 테스트하기 위한 임시 ingest API입니다.",
+        description: "개발자 또는 Swagger/curl 테스트에서 라이다 수신 흐름을 확인하기 위한 mock API입니다. 실제 라이다 PC 연동은 /api/ingest/lidar를 사용합니다.",
         requestBody: {
           required: false,
           content: {

--- a/dashboard/server/src/swagger.js
+++ b/dashboard/server/src/swagger.js
@@ -205,7 +205,7 @@ const swaggerSpec = {
       post: {
         tags: ["External Ingest"],
         summary: "통합 제어보드 mock 패킷 수신",
-        description: "RS-485 패킷 adapter 흐름을 HTTP로 먼저 테스트하기 위한 임시 API입니다. 이 단계에서는 CRC-8 실제 계산 검증은 수행하지 않습니다.",
+        description: "RS-485 10바이트 패킷 adapter 흐름을 HTTP로 먼저 테스트하기 위한 API입니다. packet이 있으면 Byte 1~6 기준 CRC-8/SMBUS를 계산해 Byte 7 값과 비교합니다.",
         requestBody: {
           required: false,
           content: {
@@ -469,6 +469,7 @@ const swaggerSpec = {
           rawSummary: {
             type: "object",
             additionalProperties: true,
+            description: "원본 payload의 필드 목록, 크기, 제어보드 패킷 파싱 결과, CRC 검증 결과를 담는 진단 정보입니다.",
           },
         },
       },
@@ -500,8 +501,16 @@ const swaggerSpec = {
               },
             ],
           },
-          command: { type: "string", enum: ["STAGE_1", "STAGE_2", "CLEAR", "UNKNOWN"], example: "STAGE_1" },
-          crcValid: { type: "boolean", example: true },
+          command: {
+            type: "string",
+            enum: ["STAGE_1_ON", "STAGE_2_ON", "STAGE_2_RETURN", "SYSTEM_RESET", "UNKNOWN"],
+            example: "STAGE_1_ON",
+          },
+          crcValid: {
+            type: "boolean",
+            example: true,
+            description: "packet 없이 command만 테스트할 때 사용하는 임시 CRC 상태 값입니다. packet이 있으면 실제 CRC-8 계산 결과가 우선 적용됩니다.",
+          },
           zone_id: { type: "string", example: "ROUNDABOUT-01" },
           device_id: { type: "string", example: "CONTROL-BOARD-01" },
         },


### PR DESCRIPTION
## 작업 내용

통합 제어보드 RS-485 패킷을 대시보드 내부 이벤트로 변환하기 위한 1차 adapter 구조를 추가했습니다.

- 10바이트 패킷 parser 추가
- STX/ID/ETX/EOF 검증 추가
- CRC-8/SMBUS 검증 추가
- 1차 경고, 2차 경고, 2차 복귀/해제, 시스템 리셋 command 매핑 추가
- 실제 수신 API `POST /api/ingest/control-board` 추가
- 테스트용 API `/mock`, `/serial/test` 유지
- Swagger 문서 갱신

## 검증

- PDF CRC 테스트 벡터 확인
- `npm run ci` 통과

## 추후 작업

현장 통신 방식과 실제 수신 패킷이 확정되면 serial reader, env 통신 설정값, command 매핑, ACK 응답 여부를 보완해야 합니다.