### PR TITLE
feat: 수신 상태 조회와 현장 테스트 가이드 추가

### DIFF
--- a/dashboard/server/src/domains/external-ingest/externalIngest.controller.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.controller.js
@@ -41,6 +41,12 @@ function getRecentEvents(req, res) {
   res.json(externalIngestService.getRecentEvents(limit));
 }
 
+// 최근 외부 장비 수신 상태를 현장 점검용으로 요약해서 반환한다.
+function getIngestStatus(req, res) {
+  // 원시 이벤트 목록 전체를 보지 않아도 마지막 수신/CRC 오류 여부를 빠르게 확인하기 위한 API다.
+  res.json(externalIngestService.getIngestStatus());
+}
+
 module.exports = {
   receiveLidar,
   receiveLidarMock,
@@ -48,4 +54,5 @@ module.exports = {
   receiveControlBoardMock,
   testControlBoardSerial,
   getRecentEvents,
+  getIngestStatus,
 };

--- a/dashboard/server/src/domains/external-ingest/externalIngest.routes.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.routes.js
@@ -10,6 +10,7 @@ router.post("/ingest/lidar/mock", controller.receiveLidarMock);
 router.post("/ingest/control-board", controller.receiveControlBoard);
 router.post("/ingest/control-board/mock", controller.receiveControlBoardMock);
 router.post("/ingest/control-board/serial/test", controller.testControlBoardSerial);
+router.get("/ingest/status", controller.getIngestStatus);
 router.get("/ingest/events/recent", controller.getRecentEvents);
 
 module.exports = router;

--- a/dashboard/server/src/domains/external-ingest/externalIngest.service.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.service.js
@@ -168,6 +168,36 @@ function getRecentEvents(limit = 20) {
   return recentEvents.slice(0, limit);
 }
 
+// 외부 장비 수신 상태를 현장 점검용으로 요약한다.
+function getIngestStatus() {
+  // DB가 붙기 전까지는 recentEvents 메모리 목록이 유일한 수신 근거다.
+  // 그래서 최근 이벤트를 기준으로 "마지막 수신 시각", "최근 오류 패킷 수", "장비별 최근 수신"만 빠르게 보여준다.
+  const now = new Date().toISOString();
+  const invalidEvents = recentEvents.filter(
+    (event) => event.rawSummary?.crcStatus === "INVALID" || event.rawSummary?.packetValid === false,
+  );
+
+  const lastLidarEvent = recentEvents.find((event) => String(event.source || "").includes("LIDAR"));
+  const lastControlBoardEvent = recentEvents.find((event) =>
+    String(event.source || "").includes("CONTROL_BOARD"),
+  );
+
+  const lastEvent = recentEvents[0] || null;
+
+  return {
+    ok: true,
+    checkedAt: now,
+    storage: "MEMORY",
+    totalRecentEvents: recentEvents.length,
+    invalidRecentEvents: invalidEvents.length,
+    lastReceivedAt: lastEvent?.receivedAt || null,
+    lastLidarReceivedAt: lastLidarEvent?.receivedAt || null,
+    lastControlBoardReceivedAt: lastControlBoardEvent?.receivedAt || null,
+    lastEvent,
+    lastInvalidEvent: invalidEvents[0] || null,
+  };
+}
+
 module.exports = {
   ingestLidarLive,
   ingestLidarMock,
@@ -175,4 +205,5 @@ module.exports = {
   ingestControlBoardMock,
   createSerialTest,
   getRecentEvents,
+  getIngestStatus,
 };

--- a/dashboard/server/src/domains/mock-lidar/mockLidar.controller.js
+++ b/dashboard/server/src/domains/mock-lidar/mockLidar.controller.js
@@ -4,6 +4,11 @@ function getState(req, res) {
   res.json(mockLidarService.getState());
 }
 
+function getControlStatus(req, res) {
+  // 현장 점검자가 차단기/VMS/라이다 표시 상태만 빠르게 확인할 수 있게 service 결과를 그대로 반환한다.
+  res.json(mockLidarService.getControlStatus());
+}
+
 function getLogs(req, res) {
   res.json(mockLidarService.getLogs(10));
 }
@@ -30,6 +35,7 @@ function passVehicle(req, res) {
 
 module.exports = {
   getState,
+  getControlStatus,
   getLogs,
   openGate,
   closeGate,

--- a/dashboard/server/src/domains/mock-lidar/mockLidar.routes.js
+++ b/dashboard/server/src/domains/mock-lidar/mockLidar.routes.js
@@ -4,6 +4,7 @@ const controller = require("./mockLidar.controller");
 const router = express.Router();
 
 router.get("/state", controller.getState);
+router.get("/control/status", controller.getControlStatus);
 router.get("/logs", controller.getLogs);
 
 router.post("/gate/open", controller.openGate);

--- a/dashboard/server/src/domains/mock-lidar/mockLidar.service.js
+++ b/dashboard/server/src/domains/mock-lidar/mockLidar.service.js
@@ -39,6 +39,26 @@ function getState() {
   return state;
 }
 
+function getControlStatus() {
+  // 현장 테스트 중에는 차단기/VMS/라이다 표시 상태를 한 번에 확인해야 한다.
+  // 기존 /state는 화면 전체 KPI까지 포함하므로, 제어 장비 확인용으로 필요한 값만 따로 묶어 반환한다.
+  return {
+    ok: true,
+    checkedAt: new Date().toISOString(),
+    siteId: state.siteId,
+    deviceId: state.deviceId,
+    gate: state.gate,
+    vmsLast: state.vmsLast,
+    lidar: state.lidar,
+    counters: {
+      todaysEvents: state.todaysEvents,
+      newEvents: state.newEvents,
+      wrongWayEvents: state.wrongWayEvents,
+      vehiclesPassed: state.vehiclesPassed,
+    },
+  };
+}
+
 function getLogs(limit = 10) {
   return logs.slice(0, limit);
 }
@@ -134,6 +154,7 @@ function broadcastDashboardEvent(dashboardEvent) {
 module.exports = {
   setBroadcaster,
   getState,
+  getControlStatus,
   getLogs,
   getWrongWayHistory,
   pushLog,

--- a/dashboard/server/src/swagger.js
+++ b/dashboard/server/src/swagger.js
@@ -127,6 +127,24 @@ const swaggerSpec = {
         },
       },
     },
+    "/api/control/status": {
+      get: {
+        tags: ["Control"],
+        summary: "제어 상태 조회",
+        description:
+          "현장 연동 테스트 중 차단기, 전광판, 라이다 표시 상태를 한 번에 확인하기 위한 API입니다. 현재는 DB 없이 메모리 상태를 반환합니다.",
+        responses: {
+          200: {
+            description: "현재 제어 상태",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ControlStatusResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/api/wrongway": {
       post: {
         tags: ["Wrongway"],
@@ -304,6 +322,24 @@ const swaggerSpec = {
         },
       },
     },
+    "/api/ingest/status": {
+      get: {
+        tags: ["External Ingest"],
+        summary: "외부 수신 상태 조회",
+        description:
+          "라이다 PC와 통합 제어보드에서 최근 수신된 이벤트를 기준으로 마지막 수신 시각, 최근 오류 패킷 수, 최근 오류 이벤트를 요약합니다. 현장 테스트에서 수신 여부를 빠르게 확인하기 위한 API입니다.",
+        responses: {
+          200: {
+            description: "외부 수신 상태 요약",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/IngestStatusResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/api/demo/start": {
       post: {
         tags: ["Demo"],
@@ -444,6 +480,33 @@ const swaggerSpec = {
           vmsLast: { type: "string", example: "역주행 차량 주의" },
         },
       },
+      ControlStatusResponse: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          checkedAt: { type: "string", format: "date-time" },
+          siteId: { type: "string", example: "Site-01" },
+          deviceId: { type: "string", example: "LIDAR-01" },
+          gate: { type: "string", enum: ["OPENED", "CLOSED"], example: "CLOSED" },
+          vmsLast: { type: "string", example: "역주행 차량 주의" },
+          lidar: {
+            type: "object",
+            properties: {
+              pts: { type: "integer", example: 2405 },
+              hz: { type: "integer", example: 10 },
+            },
+          },
+          counters: {
+            type: "object",
+            properties: {
+              todaysEvents: { type: "integer", example: 3 },
+              newEvents: { type: "integer", example: 1 },
+              wrongWayEvents: { type: "integer", example: 2 },
+              vehiclesPassed: { type: "integer", example: 12842 },
+            },
+          },
+        },
+      },
       WrongwayRequest: {
         type: "object",
         properties: {
@@ -496,6 +559,27 @@ const swaggerSpec = {
             type: "object",
             additionalProperties: true,
             description: "원본 payload의 필드 목록, 크기, 제어보드 패킷 파싱 결과, CRC 검증 결과를 담는 진단 정보입니다.",
+          },
+        },
+      },
+      IngestStatusResponse: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          checkedAt: { type: "string", format: "date-time" },
+          storage: { type: "string", example: "MEMORY" },
+          totalRecentEvents: { type: "integer", example: 5 },
+          invalidRecentEvents: { type: "integer", example: 1 },
+          lastReceivedAt: { type: "string", format: "date-time", nullable: true },
+          lastLidarReceivedAt: { type: "string", format: "date-time", nullable: true },
+          lastControlBoardReceivedAt: { type: "string", format: "date-time", nullable: true },
+          lastEvent: {
+            nullable: true,
+            oneOf: [{ $ref: "#/components/schemas/ExternalEvent" }],
+          },
+          lastInvalidEvent: {
+            nullable: true,
+            oneOf: [{ $ref: "#/components/schemas/ExternalEvent" }],
           },
         },
       },

--- a/docs/ai/project-notes.md
+++ b/docs/ai/project-notes.md
@@ -1,9 +1,76 @@
+# 현장 연동 테스트 curl
+
+아래 명령어는 대시보드 백엔드가 `http://localhost:5000`에서 실행 중이라는 전제로 작성한다.
+현장 서버 IP가 정해지면 `localhost`만 해당 IP로 바꿔서 사용한다.
+
+## 1. 서버 상태 확인
+
+```bash
+curl http://localhost:5000/api/health
+```
+
+## 2. 라이다 실제 ingest 수신 테스트
+
+```bash
+curl -X POST http://localhost:5000/api/ingest/lidar \
+  -H "Content-Type: application/json" \
+  -d "{\"zone_id\":\"ROUNDABOUT-01\",\"device_id\":\"LIDAR-01\",\"track_id\":\"track-001\",\"stage\":1,\"confidence\":0.92,\"message\":\"라이다 역주행 감지 테스트\"}"
+```
+
+## 3. 라이다 mock ingest 수신 테스트
+
+```bash
+curl -X POST http://localhost:5000/api/ingest/lidar/mock \
+  -H "Content-Type: application/json" \
+  -d "{\"zone_id\":\"ROUNDABOUT-01\",\"device_id\":\"LIDAR-MOCK-01\",\"track_id\":\"mock-track-001\",\"stage\":1,\"confidence\":0.95}"
+```
+
+## 4. 통합 제어보드 실제 ingest 수신 테스트
+
+```bash
+curl -X POST http://localhost:5000/api/ingest/control-board \
+  -H "Content-Type: application/json" \
+  -d "{\"packet\":\"02 A1 10 01 01 02 00 9B 03 0D\",\"zone_id\":\"ROUNDABOUT-01\",\"device_id\":\"CONTROL-BOARD-01\"}"
+```
+
+## 5. 통합 제어보드 mock ingest 수신 테스트
+
+```bash
+curl -X POST http://localhost:5000/api/ingest/control-board/mock \
+  -H "Content-Type: application/json" \
+  -d "{\"packet\":\"02 A1 20 01 01 02 00 CD 03 0D\",\"zone_id\":\"ROUNDABOUT-01\",\"device_id\":\"CONTROL-BOARD-MOCK-01\"}"
+```
+
+## 6. 통합 제어보드 serial reader 입력 형태 테스트
+
+```bash
+curl -X POST http://localhost:5000/api/ingest/control-board/serial/test \
+  -H "Content-Type: application/json" \
+  -d "{\"port\":\"COM3\",\"baudRate\":9600,\"samplePacket\":\"02 A1 10 02 02 02 00 1C 03 0D\"}"
+```
+
+## 7. 최근 수신 이벤트 확인
+
+```bash
+curl "http://localhost:5000/api/ingest/events/recent?limit=10"
+```
+
+## 8. 외부 수신 상태 요약 확인
+
+```bash
+curl http://localhost:5000/api/ingest/status
+```
+
+## 9. 제어 상태 확인
+
+```bash
+curl http://localhost:5000/api/control/status
+```
+
 # Project Notes
 
 이 프로젝트는 라이다 대시보드이며, 팀 개발 환경 통일을 목표로 한다.
 
-- 팀원은 Docker에 익숙하지 않을 수 있다.
-- 실행 문서와 명령은 초보자 기준으로 작성한다.
 - 백엔드, 프론트엔드, 데모 서버를 같은 방식으로 실행하는 방향을 우선한다.
 - 라이다 PC 연동 방식은 추가 협의가 필요하다.
 - 관련 경로, 포트, 프로토콜, 실행 방식, 데이터 형식은 확정 전 임의 변경하지 않는다.


### PR DESCRIPTION
## 작업 내용

- 외부 장비 수신 상태 조회 API 추가
  - `GET /api/ingest/status`
  - 최근 수신 이벤트 수
  - 최근 invalid packet 수
  - 마지막 라이다 수신 시각
  - 마지막 통합 제어보드 수신 시각
  - 마지막 수신 이벤트
  - 마지막 오류 이벤트 확인 가능

- 제어 상태 조회 API 추가
  - `GET /api/control/status`
  - 차단기 상태
  - 전광판/VMS 마지막 문구
  - 라이다 표시 상태
  - 주요 이벤트 카운터 확인 가능

- Swagger 문서 추가
  - `IngestStatusResponse`
  - `ControlStatusResponse`
  - 수신 상태/제어 상태 API 설명 추가

- 현장 연동 테스트용 curl 가이드 추가
  - 서버 상태 확인
  - 라이다 실제/mock ingest 테스트
  - 통합 제어보드 실제/mock ingest 테스트
  - serial reader 입력 형태 테스트
  - 최근 수신 이벤트 조회
  - 수신 상태/제어 상태 조회

## 검증

- `node --check dashboard/server/src/swagger.js` 통과
- `npm run ci` 통과

## 참고

- 현재 상태 조회는 DB가 아니라 메모리 기반입니다.
- 서버 재시작 시 최근 수신 이벤트는 초기화됩니다.
- 현장 서버 IP가 정해지면 curl 예시의 `localhost:5000`을 현장 IP로 변경하면 됩니다.