### PR TITLE
feat: 역주행 수신 및 제어보드 API 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ COMPOSE_DETECTOR_HOST=host.docker.internal
 SERIAL_PORT=
 BAUD_RATE=9600
 
+# 통합제어보드 이더넷 TCP 통신 설정입니다.
+# 랜선 직접 연결 테스트 시 CONTROL_BOARD_HOST에는 통합제어보드 IP를 입력합니다.
+CONTROL_BOARD_HOST=192.168.0.10
+CONTROL_BOARD_PORT=5000
+CONTROL_BOARD_TIMEOUT_MS=3000
+
 # 데모 서버에서 사용할 테스트 영상 경로입니다.
 VIDEO_SOURCE=../dashboard-web/public/wrongway_test.mp4
 

--- a/dashboard/server/src/config/index.js
+++ b/dashboard/server/src/config/index.js
@@ -25,6 +25,10 @@ const dashboardBaseUrl = (
   process.env.DASHBOARD_BASE_URL || `http://${dashboardHost}:${port}`
 ).replace(/\/+$/, "");
 
+const controlBoardHost = process.env.CONTROL_BOARD_HOST || "";
+const controlBoardPort = Number(process.env.CONTROL_BOARD_PORT || 0);
+const controlBoardTimeoutMs = Number(process.env.CONTROL_BOARD_TIMEOUT_MS || 3000);
+
 const distPath = path.join(serverRoot, "../dashboard-web/dist");
 
 module.exports = {
@@ -35,6 +39,9 @@ module.exports = {
     detectorPort,
     detectorBaseUrl,
     dashboardBaseUrl,
+    controlBoardHost,
+    controlBoardPort,
+    controlBoardTimeoutMs,
     distPath,
   },
 };

--- a/dashboard/server/src/domains/control-board/controlBoard.controller.js
+++ b/dashboard/server/src/domains/control-board/controlBoard.controller.js
@@ -1,0 +1,42 @@
+const service = require("./controlBoard.service");
+
+async function sendCommand(req, res) {
+  try {
+    // controller는 HTTP 요청/응답만 담당한다.
+    // 실제 패킷 생성, CRC 계산, TCP 전송은 service에서 처리한다.
+    const command = await service.sendControlBoardCommand(req.body || {});
+    res.json(command);
+  } catch (error) {
+    // service에서 만든 command 진단 정보가 있으면 실패 응답에도 함께 내려준다.
+    // 현장 테스트에서는 실패한 패킷과 사유를 바로 확인해야 하기 때문이다.
+    res.status(error.statusCode || 500).json({
+      ok: false,
+      message: error.message,
+      command: error.command || null,
+    });
+  }
+}
+
+function getCommand(req, res) {
+  // 메모리에 남겨둔 최근 명령 중 하나를 commandId로 찾는다.
+  // DB 저장 전 단계라 서버 재시작 시 이력은 사라진다.
+  const command = service.getCommand(req.params.id);
+  if (!command) {
+    res.status(404).json({ ok: false, message: "제어 명령을 찾을 수 없습니다." });
+    return;
+  }
+
+  res.json({ ok: true, item: command });
+}
+
+function getCommands(req, res) {
+  // 최근 명령 목록은 현장 테스트 확인용이라 기본 20건만 반환한다.
+  const limit = Number(req.query.limit) || 20;
+  res.json({ ok: true, items: service.getCommandHistory(limit) });
+}
+
+module.exports = {
+  getCommand,
+  getCommands,
+  sendCommand,
+};

--- a/dashboard/server/src/domains/control-board/controlBoard.routes.js
+++ b/dashboard/server/src/domains/control-board/controlBoard.routes.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const controller = require("./controlBoard.controller");
+
+const router = express.Router();
+
+// 대시보드 화면/Swagger/curl에서 통합제어보드로 명령을 보낼 때 사용하는 진입점이다.
+// controller -> service -> TCP client -> 통합제어보드 순서로 흐른다.
+router.post("/control-board/commands", controller.sendCommand);
+
+// 현장 테스트 중 최근에 어떤 명령을 보냈고 결과가 어땠는지 빠르게 확인하는 목록 API다.
+router.get("/control-board/commands", controller.getCommands);
+
+// 특정 commandId 하나의 전송 패킷, ACK, timeout 여부를 확인하는 상세 API다.
+router.get("/control-board/commands/:id", controller.getCommand);
+
+module.exports = router;

--- a/dashboard/server/src/domains/control-board/controlBoard.service.js
+++ b/dashboard/server/src/domains/control-board/controlBoard.service.js
@@ -1,0 +1,193 @@
+const { config } = require("../../config");
+const { logger } = require("../../utils/logger");
+const { buildControlBoardPacket, parseControlBoardPacket } = require("../external-ingest/protocol/controlBoardProtocol");
+const { sendTcpPacket } = require("./controlBoardTcp.client");
+
+// DB 테이블이 확정되기 전까지 최근 명령 결과만 메모리에 보관한다.
+// 현장 테스트에서 "방금 보낸 명령이 어떤 패킷이었는지" 확인하는 용도다.
+const MAX_COMMAND_HISTORY = 50;
+let commandHistory = [];
+
+function createCommandId() {
+  // DB 저장 전 단계라 UUID 대신 로그 추적이 가능한 간단한 commandId를 만든다.
+  return `cmd_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
+}
+
+function toHexString(buffer) {
+  // 장비 패킷/ACK는 사람이 읽기 어려운 Buffer라 HEX 문자열로 바꿔 응답과 로그에 남긴다.
+  return Array.from(buffer || [])
+    .map((byte) => byte.toString(16).toUpperCase().padStart(2, "0"))
+    .join(" ");
+}
+
+function rememberCommand(command) {
+  // 최신 명령을 맨 앞에 보관해서 GET 목록 조회 시 최근 순서로 볼 수 있게 한다.
+  commandHistory.unshift(command);
+  if (commandHistory.length > MAX_COMMAND_HISTORY) {
+    commandHistory = commandHistory.slice(0, MAX_COMMAND_HISTORY);
+  }
+}
+
+function getCommand(commandId) {
+  // commandId로 최근 명령 하나를 찾는다. 서버 재시작 시 메모리 이력은 초기화된다.
+  return commandHistory.find((command) => command.commandId === commandId) || null;
+}
+
+function getCommandHistory(limit = 20) {
+  // Swagger/현장 테스트에서 너무 많은 이력을 내려주지 않도록 limit만큼 잘라 반환한다.
+  return commandHistory.slice(0, limit);
+}
+
+async function sendControlBoardCommand(payload = {}) {
+  // HTTP 요청 하나가 들어오면 이 함수가 명령 검증부터 TCP 전송 결과 정리까지 모두 담당한다.
+  // 흐름: 요청값 검증 -> 10바이트 패킷 생성 -> dryRun 또는 TCP 전송 -> 결과 이력 저장.
+  const commandId = createCommandId();
+  const requestedAt = new Date().toISOString();
+
+  // host/port는 기본적으로 .env 값을 쓰고, 현장 임시 테스트 때는 요청 body 값으로 덮어쓸 수 있다.
+  const host = payload.host || config.controlBoardHost;
+  const port = Number(payload.port || config.controlBoardPort);
+  const timeoutMs = Number(payload.timeoutMs || config.controlBoardTimeoutMs || 3000);
+
+  // dryRun은 실제 TCP 연결 없이 패킷 생성과 CRC 검증만 보는 모드다.
+  // 장비 연결 전 Swagger/curl 테스트에서 가장 먼저 사용한다.
+  const dryRun = payload.dryRun === true;
+
+  if (!payload.commandType) {
+    // 어떤 명령을 보낼지 없으면 패킷의 MODE/STATUS/SELECT를 만들 수 없다.
+    const error = new Error("commandType은 필수입니다.");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  if (!dryRun && (!host || !port)) {
+    // 실제 전송 모드에서는 통합제어보드 IP/port가 반드시 필요하다.
+    // dryRun에서는 장비가 없어도 패킷만 확인할 수 있어 이 검사를 건너뛴다.
+    const error = new Error("통합제어보드 host/port 설정이 필요합니다.");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  // commandType을 PDF 프로토콜의 MODE/STATUS/SELECT 조합으로 바꿔 10바이트 패킷을 만든다.
+  // options 값은 현장 프로토콜 조정이 필요할 때 특정 바이트를 임시로 덮어쓰기 위한 통로다.
+  const packet = buildControlBoardPacket(payload.commandType, {
+    deviceId: payload.deviceId,
+    mode: payload.mode,
+    status: payload.status,
+    select: payload.select,
+    reserved: payload.reserved,
+  });
+
+  // dryRun/성공/실패 응답이 공통으로 공유하는 기본 진단 객체다.
+  // packet.parsed에는 우리가 만든 패킷을 다시 파싱한 결과가 들어가므로 CRC가 맞는지 바로 확인할 수 있다.
+  const baseCommand = {
+    ok: true,
+    commandId,
+    commandType: packet.command,
+    status: dryRun ? "dry-run" : "pending",
+    host: host || null,
+    port: port || null,
+    requestedAt,
+    sentAt: null,
+    ackAt: null,
+    ackReceived: false,
+    timeout: false,
+    reason: payload.reason || null,
+    zoneId: payload.zoneId || payload.zone_id || null,
+    packet: {
+      hex: packet.hex,
+      hexString: packet.hexString,
+      parsed: packet.parsed,
+    },
+    ack: null,
+  };
+
+  if (dryRun) {
+    // dryRun은 TCP client를 호출하지 않는다.
+    // 패킷 생성 결과만 저장/반환해서 실제 장비 연결 전에도 명령 프레임을 검토할 수 있게 한다.
+    rememberCommand(baseCommand);
+    logger.info("control board command dry-run", {
+      commandId,
+      commandType: packet.command,
+      packet: packet.hexString,
+    });
+    return baseCommand;
+  }
+
+  try {
+    // 여기부터 실제 장비 연결 구간이다.
+    // TCP client는 Buffer를 그대로 보내고 ACK 또는 timeout 결과를 돌려준다.
+    const sentAt = new Date().toISOString();
+    const result = await sendTcpPacket({
+      host,
+      port,
+      packetBuffer: packet.buffer,
+      timeoutMs,
+    });
+
+    // ACK도 장비 패킷이면 같은 parser로 해석한다.
+    // 아직 ACK 규격이 확정되지 않았으므로, 일단 원본 HEX와 파싱 시도 결과를 모두 남긴다.
+    const ackHexString = toHexString(result.ackBuffer);
+    const ackPacket = result.ackBuffer?.length ? parseControlBoardPacket(Array.from(result.ackBuffer)) : null;
+
+    // ACK를 받으면 ack-received, timeout이면 sent-timeout으로 구분한다.
+    // timeout은 TCP 전송 실패와 다르다. 연결/전송은 되었지만 응답을 못 받은 상태로 본다.
+    const command = {
+      ...baseCommand,
+      status: result.ackReceived ? "ack-received" : "sent-timeout",
+      sentAt,
+      ackAt: result.ackReceived ? new Date().toISOString() : null,
+      ackReceived: result.ackReceived,
+      timeout: result.timeout === true,
+      ack: result.ackBuffer?.length
+        ? {
+            hexString: ackHexString,
+            parsed: ackPacket,
+          }
+        : null,
+    };
+
+    // 성공/timeout 모두 현장 추적을 위해 이력에 남긴다.
+    rememberCommand(command);
+    logger.info("control board tcp command sent", {
+      commandId,
+      commandType: packet.command,
+      host,
+      port,
+      status: command.status,
+    });
+    return command;
+  } catch (error) {
+    // 이 구간은 TCP 연결 자체 실패, 잘못된 host/port, 네트워크 오류처럼 명령 전송이 실패한 경우다.
+    // 실패하더라도 어떤 패킷을 보내려 했는지 command에 남겨서 디버깅할 수 있게 한다.
+    const command = {
+      ...baseCommand,
+      ok: false,
+      status: "send-failed",
+      sentAt: new Date().toISOString(),
+      error: error.message,
+    };
+
+    // 실패 이력도 목록 API에서 볼 수 있게 저장한다.
+    rememberCommand(command);
+    logger.error("control board tcp command failed", {
+      commandId,
+      commandType: packet.command,
+      host,
+      port,
+      error,
+    });
+
+    // controller는 HTTP 상태만 알면 되므로, 상세 command는 error 객체에 붙여서 같이 내려준다.
+    const wrapped = new Error("통합제어보드 TCP 명령 전송에 실패했습니다.");
+    wrapped.statusCode = 502;
+    wrapped.command = command;
+    throw wrapped;
+  }
+}
+
+module.exports = {
+  getCommand,
+  getCommandHistory,
+  sendControlBoardCommand,
+};

--- a/dashboard/server/src/domains/control-board/controlBoardTcp.client.js
+++ b/dashboard/server/src/domains/control-board/controlBoardTcp.client.js
@@ -1,0 +1,69 @@
+const net = require("net");
+
+function sendTcpPacket({ host, port, packetBuffer, timeoutMs }) {
+  // TCP 소켓은 한 번 연결해서 패킷을 쓰고, ACK 또는 timeout 결과를 service에 돌려준다.
+  // 통합제어보드 응답 규격이 바뀌어도 이 함수 바깥의 API 구조는 유지하기 위한 얇은 client다.
+  return new Promise((resolve, reject) => {
+    // net.Socket은 Node.js 기본 TCP client다.
+    // HTTP가 아니라 순수 TCP 바이트 스트림으로 10바이트 패킷을 전송한다.
+    const socket = new net.Socket();
+
+    // ACK가 여러 chunk로 올 가능성을 대비해 받은 Buffer 조각을 모아둔다.
+    const chunks = [];
+
+    // connect/data/timeout/error 이벤트가 거의 동시에 올 수 있어 한 번만 종료되도록 막는다.
+    let settled = false;
+
+    function finish(result) {
+      // 성공/timeout처럼 API 응답으로 처리할 수 있는 결과는 resolve한다.
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    }
+
+    function fail(error) {
+      // 네트워크 연결 실패, 포트 오류 같은 실제 전송 실패는 reject해서 service에서 502로 바꾼다.
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      reject(error);
+    }
+
+    // 통합제어보드가 ACK를 주지 않으면 무한 대기하지 않고 timeout 결과를 반환한다.
+    socket.setTimeout(timeoutMs);
+
+    socket.once("connect", () => {
+      // 연결 성공 직후 이미 만들어진 10바이트 Buffer를 그대로 전송한다.
+      socket.write(packetBuffer);
+    });
+
+    socket.on("data", (chunk) => {
+      // 현재 구현은 첫 ACK chunk를 받으면 성공으로 본다.
+      // ACK 패킷 길이가 명확히 확정되면 여기서 길이 기준을 추가할 수 있다.
+      chunks.push(chunk);
+      finish({
+        ackReceived: true,
+        ackBuffer: Buffer.concat(chunks),
+      });
+    });
+
+    socket.once("timeout", () => {
+      // TCP 연결 또는 응답 대기가 timeout되면 전송은 시도했지만 ACK 없음으로 기록한다.
+      finish({
+        ackReceived: false,
+        timeout: true,
+        ackBuffer: Buffer.concat(chunks),
+      });
+    });
+
+    socket.once("error", fail);
+
+    // 실제 랜선 연결 테스트에서는 host가 통합제어보드 IP, port가 이더넷 설정 port다.
+    socket.connect(port, host);
+  });
+}
+
+module.exports = {
+  sendTcpPacket,
+};

--- a/dashboard/server/src/domains/external-ingest/adapters/lidarHttp.adapter.js
+++ b/dashboard/server/src/domains/external-ingest/adapters/lidarHttp.adapter.js
@@ -5,23 +5,101 @@ const {
   createRawSummary,
 } = require("../externalEvent.model");
 
+// 라이다 PC가 보내는 상황 type을 대시보드 내부 이벤트 타입으로 변환한다.
+// 외부 type 원문은 originalType으로 따로 보존하고, 내부 처리는 아래 표준 타입을 기준으로 한다.
+function mapLidarEventType(type) {
+  switch (type) {
+    case "normal-driving":
+      return EXTERNAL_EVENT_TYPE.NORMAL_DRIVING;
+    case "wrong-way-level-1":
+    case "wrong-way-level-2":
+    case "wrong-way":
+      return EXTERNAL_EVENT_TYPE.WRONG_WAY;
+    case "situation-ended":
+      return EXTERNAL_EVENT_TYPE.SITUATION_CLEARED;
+    default:
+      return EXTERNAL_EVENT_TYPE.UNKNOWN;
+  }
+}
+
+// warning_level이 없을 때 기존 stage나 type으로 화면 표시용 단계를 보정한다.
+// 정주행/상황종료는 0, 역주행 1차는 1, 역주행 2차는 2로 본다.
+function resolveWarningLevel(payload) {
+  if (payload.warning_level !== undefined && payload.warning_level !== null) {
+    return Number(payload.warning_level);
+  }
+
+  if (payload.warningLevel !== undefined && payload.warningLevel !== null) {
+    return Number(payload.warningLevel);
+  }
+
+  if (payload.stage !== undefined && payload.stage !== null) {
+    return Number(payload.stage);
+  }
+
+  if (payload.type === "wrong-way-level-1") return 1;
+  if (payload.type === "wrong-way-level-2") return 2;
+
+  return 0;
+}
+
+// 숫자형 payload는 문자열로 들어올 수 있어서 Number 변환 후 유효한 값만 넘긴다.
+function toNumberOrUndefined(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+
+  const number = Number(value);
+  return Number.isNaN(number) ? undefined : number;
+}
+
+// boolean payload는 문자열 "true"/"false"로 들어와도 내부 boolean으로 맞춘다.
+function toBooleanOrUndefined(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+
+  return undefined;
+}
+
+// 0도 의미 있는 값이므로 || 대신 null/undefined일 때만 대체값을 사용한다.
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null);
+}
+
 // 라이다 HTTP payload를 내부 표준 이벤트로 바꾸는 adapter 함수다.
 function adaptLidarHttpPayload(payload = {}) {
-  // 라이다 PC에서 HTTP/JSON으로 들어온 데이터를 내부 표준 이벤트로 변환한다.
-  // 아직 조선대 측 실제 데이터 규격이 없으므로 id, zone_id, track_id처럼 자주 쓰일 후보 필드를 우선 흡수한다.
-  // 나중에 실제 예시 데이터가 오면 이 adapter만 수정하고, service/controller 흐름은 유지하는 것이 목표다.
+  const originalType = firstDefined(payload.type, payload.event_type, payload.eventType);
+  const warningLevel = resolveWarningLevel(payload);
+  const externalZoneId = firstDefined(payload.zone_id, payload.zoneId, payload.external_zone_id);
+
+  // 라이다 PC 최신 JSON 규격을 내부 표준 이벤트로 변환한다.
+  // 여기서는 DB에 직접 저장하지 않고, service가 저장 정책을 결정할 수 있도록 원본/정규화 필드를 모두 보존한다.
   return createExternalEvent({
     id: payload.id || payload.event_id || payload.eventCode,
     source: EXTERNAL_EVENT_SOURCE.LIDAR_PC,
-    eventType: EXTERNAL_EVENT_TYPE.WRONG_WAY,
-    stage: payload.stage,
+    eventType: mapLidarEventType(originalType),
+    originalType,
+    warningLevel,
+    stage: warningLevel,
     siteId: payload.site_id || payload.siteId,
-    zoneId: payload.zone_id || payload.zoneId,
+    zoneId: externalZoneId,
+    externalZoneId,
     deviceId: payload.device_id || payload.deviceId || payload.serial_no,
     trackId: payload.track_id || payload.trackId || payload.object_id,
     message: payload.message || "라이다 역주행 감지 이벤트 수신",
     occurredAt: payload.timestamp || payload.occurred_at || payload.occurredAt,
-    confidence: payload.confidence,
+    confidence: toNumberOrUndefined(payload.confidence),
+    speedMs: toNumberOrUndefined(firstDefined(payload.speed_ms, payload.speedMs)),
+    speedKmh: toNumberOrUndefined(firstDefined(payload.speed_kmh, payload.speedKmh)),
+    objectClass: toNumberOrUndefined(firstDefined(payload.object_class, payload.objectClass)),
+    description: payload.description,
+    consecutiveCount: toNumberOrUndefined(
+      firstDefined(payload.consecutive_count, payload.consecutiveCount),
+    ),
+    isConfirmed: toBooleanOrUndefined(payload.is_confirmed ?? payload.isConfirmed),
+    normalMovingVehicleCount: toNumberOrUndefined(
+      firstDefined(payload.normal_moving_vehicle_count, payload.normalMovingVehicleCount),
+    ),
     rawPayload: payload,
     rawSummary: createRawSummary(payload),
   });
@@ -29,4 +107,5 @@ function adaptLidarHttpPayload(payload = {}) {
 
 module.exports = {
   adaptLidarHttpPayload,
+  mapLidarEventType,
 };

--- a/dashboard/server/src/domains/external-ingest/externalEvent.model.js
+++ b/dashboard/server/src/domains/external-ingest/externalEvent.model.js
@@ -10,6 +10,7 @@ const EXTERNAL_EVENT_SOURCE = {
 
 // eventType은 화면 반영 방식과 이력 분류를 결정하는 내부 이벤트 종류다.
 const EXTERNAL_EVENT_TYPE = {
+  NORMAL_DRIVING: "NORMAL_DRIVING",
   WRONG_WAY: "WRONG_WAY",
   CONTROL_STAGE: "CONTROL_STAGE",
   SITUATION_CLEARED: "SITUATION_CLEARED",
@@ -74,9 +75,13 @@ function createExternalEvent(input) {
     id: input.id || createEventId(),
     source: input.source,
     eventType: input.eventType || EXTERNAL_EVENT_TYPE.UNKNOWN,
+    // originalType은 라이다 PC가 보낸 type 원문을 보존해서, 추후 DB/화면/디버깅에서 외부 규격 그대로 확인할 수 있게 한다.
+    originalType: input.originalType,
+    warningLevel: input.warningLevel,
     stage: Number(input.stage) || 0,
     siteId: input.siteId || "Site-01",
     zoneId: input.zoneId || "UNKNOWN",
+    externalZoneId: input.externalZoneId || input.zoneId || "UNKNOWN",
     deviceId: input.deviceId || "UNKNOWN",
     trackId: input.trackId,
     message: input.message || "External event received",
@@ -86,6 +91,14 @@ function createExternalEvent(input) {
     isOccurredAtValid: occurredAtInfo.isOccurredAtValid,
     timeSkewMs: occurredAtInfo.timeSkewMs,
     confidence: input.confidence,
+    speedMs: input.speedMs,
+    speedKmh: input.speedKmh,
+    objectClass: input.objectClass,
+    objectUuid: input.objectUuid,
+    description: input.description,
+    consecutiveCount: input.consecutiveCount,
+    isConfirmed: input.isConfirmed,
+    normalMovingVehicleCount: input.normalMovingVehicleCount,
     rawPayload: input.rawPayload ?? input.raw ?? null,
     rawSummary: input.rawSummary || createRawSummary(input.rawPayload ?? input.raw),
   };

--- a/dashboard/server/src/domains/external-ingest/protocol/controlBoardProtocol.js
+++ b/dashboard/server/src/domains/external-ingest/protocol/controlBoardProtocol.js
@@ -38,8 +38,51 @@ const SELECT_LABEL = {
   0x12: "BARRIER_ONLY",
 };
 
+// 대시보드에서 보내는 추상 명령을 실제 10바이트 패킷의 핵심 바이트로 바꾸는 표다.
+// Byte 3 MODE, Byte 4 STATUS, Byte 5 SELECT 조합이 실제 통합제어보드 동작 의미를 결정한다.
+const COMMAND_PACKET_MAP = {
+  // 1차 경고: 경고 설비 묶음만 ON으로 보는 기본 명령이다.
+  STAGE_1_ON: { mode: 0x01, status: 0x01, select: 0x02 },
+
+  // 2차 경고: 전체 설비 또는 안전 설비까지 포함해 강한 제어를 걸 때 쓰는 명령이다.
+  STAGE_2_ON: { mode: 0x02, status: 0x01, select: 0x01 },
+
+  // 2차 복귀/상황 해제: 차단기 복귀 또는 안전 설비 해제 흐름으로 해석한다.
+  STAGE_2_RETURN: { mode: 0x02, status: 0x02, select: 0x03 },
+
+  // 전체 리셋: 대기 상태로 돌리는 명령이다.
+  SYSTEM_RESET: { mode: 0x00, status: 0x00, select: 0x01 },
+};
+
+// API 사용자가 STAGE_1_ON 같은 내부 명칭을 몰라도 의미가 같은 값을 넣을 수 있게 별칭을 둔다.
+// 예: wrong-way-level-1, warning_level_1 같은 입력은 모두 STAGE_1_ON으로 정규화된다.
+const COMMAND_ALIAS = {
+  WARNING_LEVEL_1: "STAGE_1_ON",
+  WRONG_WAY_LEVEL_1: "STAGE_1_ON",
+  STAGE_1: "STAGE_1_ON",
+  WARNING_LEVEL_2: "STAGE_2_ON",
+  WRONG_WAY_LEVEL_2: "STAGE_2_ON",
+  STAGE_2: "STAGE_2_ON",
+  SITUATION_ENDED: "STAGE_2_RETURN",
+  SITUATION_CLEARED: "STAGE_2_RETURN",
+  RETURN: "STAGE_2_RETURN",
+  RESET: "SYSTEM_RESET",
+};
+
 function toHex(byte) {
+  // 숫자 바이트를 디버깅하기 쉬운 0xNN 형태로 바꾼다.
   return `0x${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+}
+
+function toHexString(bytes) {
+  // Buffer/byte 배열을 Swagger 응답에서 읽기 좋은 "02 A1 ..." 형태로 바꾼다.
+  return bytes.map((byte) => byte.toString(16).toUpperCase().padStart(2, "0")).join(" ");
+}
+
+function normalizeCommand(commandType) {
+  // 외부 입력은 케밥케이스/스네이크케이스/대소문자가 섞일 수 있어 내부 명령명으로 통일한다.
+  const normalized = String(commandType || "").trim().replace(/-/g, "_").toUpperCase();
+  return COMMAND_ALIAS[normalized] || normalized;
 }
 
 function parseByteToken(token) {
@@ -120,6 +163,57 @@ function getProtocolCommand(parsed) {
   if (parsed.mode === "STAGE_2" && parsed.status === "BARRIER_RETURN") return "STAGE_2_RETURN";
   if (parsed.mode === "WAIT" && parsed.status === "OFF") return "SYSTEM_RESET";
   return "UNKNOWN";
+}
+
+function buildControlBoardPacket(commandType, options = {}) {
+  // 대시보드가 통합제어보드로 보낼 명령을 PDF 기준 10바이트 프레임으로 만든다.
+  // TCP는 이 바이트 배열을 운반만 하므로, 장비 프로토콜에서 요구하는 CRC-8은 여기서 직접 계산해 넣는다.
+  const command = normalizeCommand(commandType);
+  const mapping = COMMAND_PACKET_MAP[command];
+
+  if (!mapping) {
+    // 지원하지 않는 명령은 임의 패킷을 만들지 않는다.
+    // 현장 장비 제어이므로 알 수 없는 명령을 조용히 전송하면 더 위험하다.
+    throw new Error(`지원하지 않는 통합제어보드 명령입니다: ${commandType}`);
+  }
+
+  // 10바이트 프레임 구조:
+  // [0] STX, [1] ID, [2] TYPE, [3] MODE, [4] STATUS,
+  // [5] SELECT, [6] RESERVED, [7] CRC, [8] ETX, [9] EOF.
+  const bytes = [
+    STX,
+    options.deviceId ?? DEVICE_ID,
+    // 0x10은 대시보드/PC가 통합제어보드로 보내는 명령 패킷을 의미한다.
+    0x10,
+    options.mode ?? mapping.mode,
+    options.status ?? mapping.status,
+    options.select ?? mapping.select,
+    options.reserved ?? 0x00,
+    0x00,
+    ETX,
+    EOF,
+  ];
+
+  // CRC 계산 범위는 수신 파서와 동일하게 Byte 1~6이다.
+  bytes[7] = calculateCrc8Smbus(bytes.slice(1, 7));
+
+  return {
+    // 정규화된 내부 명령명이다. API 응답과 로그에서 같은 기준으로 추적한다.
+    command,
+
+    // 실제 TCP 전송에 사용할 숫자 바이트 배열이다.
+    bytes,
+
+    // 사람이 보기 쉬운 HEX 배열/문자열이다.
+    hex: bytes.map(toHex),
+    hexString: toHexString(bytes),
+
+    // Node net.Socket.write에 그대로 넘길 Buffer다.
+    buffer: Buffer.from(bytes),
+
+    // 우리가 만든 패킷을 다시 파싱해서 CRC/프레임 구조가 맞는지 자체 검증한 결과다.
+    parsed: parseControlBoardPacket(bytes),
+  };
 }
 
 function parseControlBoardPacket(packet) {
@@ -214,6 +308,8 @@ function parseControlBoardPacket(packet) {
 }
 
 module.exports = {
+  buildControlBoardPacket,
   calculateCrc8Smbus,
+  normalizeCommand,
   parseControlBoardPacket,
 };

--- a/dashboard/server/src/domains/wrongway/wrongway.controller.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.controller.js
@@ -1,61 +1,50 @@
-const { nowTime } = require("../../utils/time");
 const { logger } = require("../../utils/logger");
 const mockLidarService = require("../mock-lidar/mockLidar.service");
+const wrongwayService = require("./wrongway.service");
 
-function receiveWrongWay(req, res) {
-  const body = req.body || {};
-  logger.info("wrongway payload received", {
-    id: body.id,
-    stage: body.stage,
-    zoneId: body.zone_id,
-    trackId: body.track_id,
-  });
-  logger.debug("wrongway payload shape received", {
-    payloadKeys: Object.keys(body),
-    payloadSize: JSON.stringify(body).length,
-  });
+async function receiveWrongWay(req, res) {
+  try {
+    const body = req.body || {};
 
-  const dashboardEvent = {
-    id: body.id || `evt-${Date.now()}`,
-    type: "wrong-way",
-    stage: Number(body.stage) || 1,
-    message: "WRONG WAY DETECTION",
-    subMessage: body.message || `Zone: ${body.zone_id || "UNKNOWN"}`,
-    timestamp: body.timestamp
-      ? new Date(body.timestamp).toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-        })
-      : nowTime(),
-    zone_id: body.zone_id,
-    track_id: body.track_id,
-    confidence: body.confidence,
-    video_ts_ms: body.video_ts_ms,
-    device_id: body.device_id,
-    serial_no: body.serial_no,
-    snapshot: body.snapshot,
-  };
+    logger.info("wrongway payload received", {
+      type: body.type,
+      warningLevel: body.warning_level,
+      zoneId: body.zone_id,
+      trackId: body.track_id,
+    });
+    logger.debug("wrongway payload shape received", {
+      payloadKeys: Object.keys(body),
+      payloadSize: JSON.stringify(body).length,
+    });
 
-  logger.info("wrongway dashboard event broadcast", {
-    id: dashboardEvent.id,
-    stage: dashboardEvent.stage,
-    subMessage: dashboardEvent.subMessage,
-  });
+    const result = await wrongwayService.receiveWrongWayPayload(body);
+    res.status(result.stored ? 201 : 200).json(result);
+  } catch (error) {
+    logger.error("wrongway payload failed", {
+      message: error.message,
+      details: error.details,
+    });
 
-  mockLidarService.applyDashboardEventEffects(dashboardEvent);
-  mockLidarService.addWrongWayHistory(dashboardEvent);
-  mockLidarService.broadcastDashboardEvent(dashboardEvent);
-  mockLidarService.pushLog(`[WRONGWAY] ${dashboardEvent.subMessage}`);
-
-  res.json({ ok: true });
+    res.status(error.statusCode || 500).json({
+      ok: false,
+      message: error.message || "역주행 데이터 수신 처리 중 오류가 발생했습니다.",
+      details: error.details,
+    });
+  }
 }
 
 function getWrongWayHistory(req, res) {
   res.json(mockLidarService.getWrongWayHistory());
 }
 
+function getWrongWayTestPayloads(req, res) {
+  const host = req.get("host") || "localhost:5000";
+  const protocol = req.protocol || "http";
+  res.json(wrongwayService.getTestPayloads(`${protocol}://${host}`));
+}
+
 module.exports = {
   receiveWrongWay,
   getWrongWayHistory,
+  getWrongWayTestPayloads,
 };

--- a/dashboard/server/src/domains/wrongway/wrongway.routes.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.routes.js
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.post("/wrongway", controller.receiveWrongWay);
 router.get("/wrongway/history", controller.getWrongWayHistory);
+router.get("/wrongway/test-payloads", controller.getWrongWayTestPayloads);
 
 module.exports = router;

--- a/dashboard/server/src/domains/wrongway/wrongway.service.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.service.js
@@ -1,0 +1,301 @@
+const { prisma } = require("../../prisma/client");
+const { logger } = require("../../utils/logger");
+const mockLidarService = require("../mock-lidar/mockLidar.service");
+const { adaptLidarHttpPayload } = require("../external-ingest/adapters/lidarHttp.adapter");
+
+const WRONGWAY_LEVEL_1 = "wrong-way-level-1";
+const NORMAL_DRIVING = "normal-driving";
+
+function createHttpError(statusCode, message, details) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  error.details = details;
+  return error;
+}
+
+function toDateOrNull(value) {
+  if (!value) return null;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+async function findZoneByExternalCode(externalZoneId) {
+  if (!externalZoneId) return null;
+
+  return prisma.zone.findFirst({
+    where: { zoneCode: externalZoneId },
+  });
+}
+
+function toDashboardEvent(event, trafficEvent) {
+  return {
+    id: trafficEvent?.id || event.id,
+    type: "wrong-way",
+    stage: event.warningLevel || event.stage || 1,
+    message: event.message || "역주행 1차 감지",
+    subMessage: `Zone: ${event.externalZoneId || event.zoneId || "UNKNOWN"}`,
+    timestamp: event.occurredAt
+      ? new Date(event.occurredAt).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        })
+      : new Date(event.receivedAt).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        }),
+    zone_id: event.externalZoneId || event.zoneId,
+    track_id: event.trackId,
+    confidence: event.confidence,
+    source: event.source,
+  };
+}
+
+async function countNormalDrivingTracks() {
+  return prisma.vehicleTrack.count({
+    where: { lastEventType: NORMAL_DRIVING },
+  });
+}
+
+async function upsertVehicleTrack(event, zone) {
+  // 정주행 payload는 1초마다 반복될 수 있으므로, track_id 기준으로 새 행을 계속 만들지 않고 최신 상태만 갱신한다.
+  return prisma.vehicleTrack.upsert({
+    where: { trackId: event.trackId },
+    update: {
+      zoneId: zone?.id || null,
+      externalZoneId: event.externalZoneId,
+      lastEventType: event.originalType || event.eventType,
+      lastWarningLevel: event.warningLevel,
+      objectClass: event.objectClass,
+      lastSeenAt: toDateOrNull(event.occurredAt) || new Date(event.receivedAt),
+      rawPayload: event.rawPayload,
+    },
+    create: {
+      trackId: event.trackId,
+      zoneId: zone?.id || null,
+      externalZoneId: event.externalZoneId,
+      lastEventType: event.originalType || event.eventType,
+      lastWarningLevel: event.warningLevel,
+      objectClass: event.objectClass,
+      firstSeenAt: toDateOrNull(event.occurredAt) || new Date(event.receivedAt),
+      lastSeenAt: toDateOrNull(event.occurredAt) || new Date(event.receivedAt),
+      rawPayload: event.rawPayload,
+    },
+  });
+}
+
+async function updateTrackNormalCount(vehicleTrackId, normalMovingVehicleCount) {
+  return prisma.vehicleTrack.update({
+    where: { id: vehicleTrackId },
+    data: { lastNormalMovingVehicleCount: normalMovingVehicleCount },
+  });
+}
+
+async function findDuplicatedLevel1Event(event) {
+  // 역주행 1차는 같은 차량/같은 단계가 반복 저장되지 않도록 먼저 기존 이벤트를 조회한다.
+  return prisma.trafficEvent.findFirst({
+    where: {
+      trackId: event.trackId,
+      eventType: WRONGWAY_LEVEL_1,
+      warningLevel: 1,
+    },
+    orderBy: { receivedAt: "desc" },
+  });
+}
+
+async function createLevel1TrafficEvent(event, zone, vehicleTrack, normalMovingVehicleCount) {
+  const trafficEvent = await prisma.trafficEvent.create({
+    data: {
+      eventType: WRONGWAY_LEVEL_1,
+      status: "NEW",
+      occurredAt: toDateOrNull(event.occurredAt),
+      receivedAt: new Date(event.receivedAt),
+      zoneId: zone?.id || null,
+      vehicleTrackId: vehicleTrack.id,
+      externalZoneId: event.externalZoneId,
+      trackId: event.trackId,
+      warningLevel: 1,
+      confidence: event.confidence,
+      message: event.message,
+      speedMs: event.speedMs,
+      speedKmh: event.speedKmh,
+      objectClass: event.objectClass,
+      description: event.description,
+      consecutiveCount: event.consecutiveCount,
+      isConfirmed: event.isConfirmed,
+      normalMovingVehicleCount,
+      rawPayload: event.rawPayload,
+    },
+  });
+
+  await prisma.eventLog.create({
+    data: {
+      eventId: trafficEvent.id,
+      action: "EVENT_RECEIVED",
+      message: "역주행 1차 감지 이벤트를 수신했습니다.",
+      metadata: {
+        source: event.source,
+        externalZoneId: event.externalZoneId,
+        trackId: event.trackId,
+        originalType: event.originalType,
+      },
+    },
+  });
+
+  return trafficEvent;
+}
+
+function applyLevel1DashboardEffects(event, trafficEvent) {
+  const dashboardEvent = toDashboardEvent(event, trafficEvent);
+
+  mockLidarService.applyDashboardEventEffects(dashboardEvent);
+  mockLidarService.addWrongWayHistory(dashboardEvent);
+  mockLidarService.broadcastDashboardEvent(dashboardEvent);
+  mockLidarService.pushLog(`[WRONGWAY] ${dashboardEvent.message} / ${dashboardEvent.subMessage}`);
+}
+
+async function receiveWrongWayPayload(payload = {}) {
+  const event = adaptLidarHttpPayload(payload);
+
+  if (!event.originalType) {
+    throw createHttpError(400, "type 값이 필요합니다.", { field: "type" });
+  }
+
+  if (!event.trackId) {
+    throw createHttpError(400, "track_id 값이 필요합니다.", { field: "track_id" });
+  }
+
+  const zone = await findZoneByExternalCode(event.externalZoneId);
+  const vehicleTrack = await upsertVehicleTrack(event, zone);
+  const normalMovingVehicleCount = await countNormalDrivingTracks();
+
+  await updateTrackNormalCount(vehicleTrack.id, normalMovingVehicleCount);
+
+  logger.info("wrongway payload adapted", {
+    type: event.originalType,
+    trackId: event.trackId,
+    externalZoneId: event.externalZoneId,
+    warningLevel: event.warningLevel,
+  });
+
+  if (event.originalType === NORMAL_DRIVING) {
+    return {
+      ok: true,
+      stored: false,
+      duplicated: false,
+      reason: "TRACK_UPDATED",
+      eventId: null,
+      trackId: event.trackId,
+      type: event.originalType,
+      warningLevel: event.warningLevel,
+      normalMovingVehicleCount,
+      receivedAt: event.receivedAt,
+    };
+  }
+
+  if (event.originalType !== WRONGWAY_LEVEL_1 || event.warningLevel !== 1) {
+    return {
+      ok: true,
+      stored: false,
+      duplicated: false,
+      reason: "NOT_IMPLEMENTED_YET",
+      eventId: null,
+      trackId: event.trackId,
+      type: event.originalType,
+      warningLevel: event.warningLevel,
+      normalMovingVehicleCount,
+      receivedAt: event.receivedAt,
+    };
+  }
+
+  const duplicatedEvent = await findDuplicatedLevel1Event(event);
+  if (duplicatedEvent) {
+    return {
+      ok: true,
+      stored: false,
+      duplicated: true,
+      reason: "DUPLICATED_WRONGWAY_LEVEL_1",
+      eventId: duplicatedEvent.id,
+      trackId: event.trackId,
+      type: event.originalType,
+      warningLevel: event.warningLevel,
+      normalMovingVehicleCount,
+      receivedAt: event.receivedAt,
+    };
+  }
+
+  const trafficEvent = await createLevel1TrafficEvent(
+    event,
+    zone,
+    vehicleTrack,
+    normalMovingVehicleCount,
+  );
+
+  applyLevel1DashboardEffects(event, trafficEvent);
+
+  return {
+    ok: true,
+    stored: true,
+    duplicated: false,
+    reason: "WRONGWAY_LEVEL_1_STORED",
+    eventId: trafficEvent.id,
+    trackId: event.trackId,
+    type: event.originalType,
+    warningLevel: event.warningLevel,
+    normalMovingVehicleCount,
+    receivedAt: event.receivedAt,
+  };
+}
+
+function getTestPayloads(baseUrl = "http://localhost:5000") {
+  const endpoint = `${baseUrl.replace(/\/+$/, "")}/api/wrongway`;
+
+  const normalDriving = {
+    type: "normal-driving",
+    warning_level: 0,
+    timestamp: "2026-01-13T14:43:53.860089+09:00",
+    confidence: 1.0,
+    zone_id: "Z261",
+    track_id: "54750000-0000-0000-0000-000000000000",
+    message: "정주행",
+    speed_ms: 0.5792374909226594,
+    speed_kmh: 2.085254967321574,
+    object_class: 1,
+    description: "Normal",
+    consecutive_count: 0,
+    is_confirmed: false,
+  };
+
+  const wrongWayLevel1 = {
+    type: "wrong-way-level-1",
+    warning_level: 1,
+    timestamp: "2026-01-13T14:43:54.360258+09:00",
+    confidence: 0.95,
+    zone_id: "Z327",
+    track_id: "81760000-0000-0000-0000-000000000000",
+    message: "역주행 1차 감지",
+    speed_ms: 2.835765050970876,
+    speed_kmh: 10.208754183495154,
+    object_class: 6,
+    description: "Wrong-way driving detected (Heading and Path Confirmed)",
+    consecutive_count: 3,
+    is_confirmed: true,
+  };
+
+  return {
+    ok: true,
+    endpoint,
+    note: "다른 PC에서는 localhost 대신 대시보드 서버 PC의 내부망 IP를 사용합니다.",
+    payloads: {
+      normalDriving,
+      wrongWayLevel1,
+    },
+  };
+}
+
+module.exports = {
+  receiveWrongWayPayload,
+  getTestPayloads,
+};

--- a/dashboard/server/src/routes/index.js
+++ b/dashboard/server/src/routes/index.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const controlBoardRoutes = require("../domains/control-board/controlBoard.routes");
 const databaseRoutes = require("../domains/database/database.routes");
 const demoRoutes = require("../domains/demo/demo.routes");
 const externalIngestRoutes = require("../domains/external-ingest/externalIngest.routes");
@@ -12,6 +13,7 @@ router.get("/health", (req, res) => {
 });
 
 router.use(demoRoutes);
+router.use(controlBoardRoutes);
 router.use(databaseRoutes);
 router.use(externalIngestRoutes);
 router.use(mockLidarRoutes);

--- a/dashboard/server/src/swagger.js
+++ b/dashboard/server/src/swagger.js
@@ -16,6 +16,7 @@ const swaggerSpec = {
     { name: "Database", description: "DB 연결과 기본 테이블 확인" },
     { name: "Dashboard", description: "대시보드 상태와 로그 조회" },
     { name: "Control", description: "차단기와 전광판 제어" },
+    { name: "Control Board", description: "통합제어보드 이더넷 TCP 명령 전송" },
     { name: "Wrongway", description: "역주행 감지 이벤트" },
     { name: "External Ingest", description: "라이다 PC와 통합 제어보드 외부 이벤트 수신" },
     { name: "Demo", description: "감지 데모 제어" },
@@ -166,6 +167,117 @@ const swaggerSpec = {
             content: {
               "application/json": {
                 schema: { $ref: "#/components/schemas/ControlStatusResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/control-board/commands": {
+      post: {
+        tags: ["Control Board"],
+        summary: "통합제어보드 TCP 명령 전송",
+        description:
+          "대시보드 서버가 RS-485 10바이트 프로토콜 프레임을 생성한 뒤, 이더넷 TCP 소켓으로 통합제어보드에 전송합니다. dryRun이 true이면 실제 TCP 전송 없이 패킷 생성과 CRC-8 계산만 확인합니다.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ControlBoardCommandRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "통합제어보드 명령 처리 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ControlBoardCommandResponse" },
+              },
+            },
+          },
+          400: {
+            description: "요청값 또는 통합제어보드 접속 설정 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          502: {
+            description: "통합제어보드 TCP 전송 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      get: {
+        tags: ["Control Board"],
+        summary: "최근 통합제어보드 명령 목록 조회",
+        parameters: [
+          {
+            name: "limit",
+            in: "query",
+            required: false,
+            schema: { type: "integer", example: 20 },
+          },
+        ],
+        responses: {
+          200: {
+            description: "최근 명령 목록",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    ok: { type: "boolean", example: true },
+                    items: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/ControlBoardCommandResponse" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/control-board/commands/{id}": {
+      get: {
+        tags: ["Control Board"],
+        summary: "통합제어보드 명령 결과 조회",
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string", example: "cmd_123456" },
+          },
+        ],
+        responses: {
+          200: {
+            description: "명령 상세 결과",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    ok: { type: "boolean", example: true },
+                    item: { $ref: "#/components/schemas/ControlBoardCommandResponse" },
+                  },
+                },
+              },
+            },
+          },
+          404: {
+            description: "명령 ID를 찾을 수 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
               },
             },
           },
@@ -562,6 +674,79 @@ const swaggerSpec = {
               wrongWayEvents: { type: "integer", example: 2 },
               vehiclesPassed: { type: "integer", example: 12842 },
             },
+          },
+        },
+      },
+      ControlBoardCommandRequest: {
+        type: "object",
+        required: ["commandType"],
+        properties: {
+          commandType: {
+            type: "string",
+            enum: [
+              "STAGE_1_ON",
+              "STAGE_2_ON",
+              "STAGE_2_RETURN",
+              "SYSTEM_RESET",
+              "warning_level_1",
+              "warning_level_2",
+              "situation_ended",
+            ],
+            example: "STAGE_1_ON",
+            description: "통합제어보드로 보낼 명령 유형입니다. 별칭은 내부에서 PDF 프로토콜 명령으로 변환합니다.",
+          },
+          zoneId: { type: "string", example: "zone-1" },
+          reason: { type: "string", example: "wrong-way-level-1" },
+          host: {
+            type: "string",
+            example: "192.168.0.10",
+            description: ".env의 CONTROL_BOARD_HOST 대신 임시 테스트 IP를 지정할 때 사용합니다.",
+          },
+          port: {
+            type: "integer",
+            example: 5000,
+            description: ".env의 CONTROL_BOARD_PORT 대신 임시 테스트 port를 지정할 때 사용합니다.",
+          },
+          timeoutMs: { type: "integer", example: 3000 },
+          dryRun: {
+            type: "boolean",
+            example: true,
+            description: "true이면 실제 TCP 전송 없이 10바이트 패킷과 CRC-8 계산 결과만 확인합니다.",
+          },
+        },
+      },
+      ControlBoardCommandResponse: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          commandId: { type: "string", example: "cmd_123456" },
+          commandType: { type: "string", example: "STAGE_1_ON" },
+          status: {
+            type: "string",
+            enum: ["dry-run", "pending", "ack-received", "sent-timeout", "send-failed"],
+            example: "dry-run",
+          },
+          host: { type: "string", nullable: true, example: "192.168.0.10" },
+          port: { type: "integer", nullable: true, example: 5000 },
+          requestedAt: { type: "string", format: "date-time" },
+          sentAt: { type: "string", format: "date-time", nullable: true },
+          ackAt: { type: "string", format: "date-time", nullable: true },
+          ackReceived: { type: "boolean", example: false },
+          timeout: { type: "boolean", example: false },
+          packet: {
+            type: "object",
+            properties: {
+              hexString: {
+                type: "string",
+                example: "02 A1 10 01 01 02 00 49 03 0D",
+              },
+              parsed: { type: "object", additionalProperties: true },
+            },
+          },
+          ack: {
+            type: "object",
+            nullable: true,
+            additionalProperties: true,
           },
         },
       },


### PR DESCRIPTION
## 작업 내용

- 라이다 PC 수신 payload 기준으로 `/api/wrongway` 처리 흐름을 정리했습니다.
- 정주행 데이터는 `VehicleTrack` 기준으로 최신 상태를 갱신하도록 구현했습니다.
- 역주행 1차 데이터는 `TrafficEvent`로 저장하고, 동일 `track_id` 기준 중복 저장을 방지했습니다.
- 테스트용 payload 조회 API를 추가했습니다.
- 통합제어보드 이더넷 TCP 명령 전송 API를 추가했습니다.
- 통합제어보드 RS-485 10바이트 프로토콜 기준으로 패킷 생성, CRC-8 계산, dryRun 검증 흐름을 구현했습니다.
- Swagger 명세에 신규 API를 반영했습니다.
- 흐름 이해를 위해 주요 service, adapter, TCP client, protocol 코드에 한글 주석을 보강했습니다.

## 주요 API

### 라이다 수신

- `POST /api/wrongway`
  - `normal-driving`: `VehicleTrack` upsert로 차량 최신 상태 갱신
  - `wrong-way-level-1`: `TrafficEvent` 저장
  - 동일 `track_id` + 동일 이벤트 단계 기준 중복 저장 방지

- `GET /api/wrongway/test-payloads`
  - 정주행/역주행 테스트 payload 조회

### 통합제어보드

- `POST /api/control-board/commands`
  - 대시보드 → 통합제어보드 TCP 명령 전송
  - `dryRun: true` 사용 시 실제 전송 없이 패킷/CRC 검증

- `GET /api/control-board/commands`
  - 최근 제어 명령 이력 조회

- `GET /api/control-board/commands/{id}`
  - 특정 제어 명령 결과 조회

## 검증

- [x] `npm run ci`
- [x] 프론트엔드 production build
- [x] 백엔드 syntax check
- [x] 통합제어보드 dryRun 패킷 생성 및 CRC 검증

## 참고

- 통합제어보드 실제 TCP 전송은 장비 IP/Port 설정 후 현장 또는 랜선 직접 연결 환경에서 추가 검증이 필요합니다.
- 현재 통합제어보드 명령 이력은 DB 저장 전 단계로 메모리에 보관합니다.
- Vite build 시 browserslist/chunk size 경고가 출력되지만 빌드 실패는 아닙니다.