### PR TITLE
test: 라이다 수신 테스트 도구 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ VITE_API_BASE_URL=http://localhost:5000
 VITE_WS_BASE_URL=ws://localhost:5000
 VITE_DETECTOR_BASE_URL=http://localhost:8888
 
+# 라이다 수신 테스트 스크립트가 요청을 보낼 백엔드 Base URL입니다.
+# 다른 노트북/내부망 서버로 보낼 때 이 값을 대상 서버 주소로 변경합니다.
+WRONGWAY_TEST_BASE_URL=http://localhost:5000
+
 # Docker Compose 내부 통신에 사용하는 서비스 호스트명입니다.
 # demo-server를 Docker로 함께 실행할 때만 COMPOSE_DETECTOR_HOST=demo-server로 변경합니다.
 COMPOSE_BACKEND_HOST=backend

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dashboard/dashboard-web/dist/
 config.json
 dashboard/server/config.json
 dashboard/demo-server/config.json
+scripts/wrongway-test.config.json
 
 # Local editor/tool settings
 .vscode/

--- a/README.md
+++ b/README.md
@@ -139,6 +139,157 @@ curl http://localhost:5000/api/database/health
 }
 ```
 
+## 라이다 수신 테스트
+
+라이다 PC 없이도 `/api/wrongway` 수신, `VehicleTrack` 갱신, `TrafficEvent` 저장 흐름을 테스트할 수 있습니다.
+
+Swagger에서 확인:
+
+```txt
+http://localhost:5000/api-docs
+```
+
+Swagger 주요 테스트 API:
+
+```txt
+GET  /api/wrongway/test-payloads
+POST /api/wrongway/test/normal
+POST /api/wrongway/test/normal-stream/start
+POST /api/wrongway/test/normal-stream/stop
+GET  /api/wrongway/test/normal-stream/status
+POST /api/wrongway/test/wrong-way-level-1
+```
+
+로컬 스크립트 실행:
+
+```bash
+npm run test:wrongway-samples
+```
+
+기본 대상 서버는 루트 `.env`의 `WRONGWAY_TEST_BASE_URL`을 사용합니다.
+
+```env
+WRONGWAY_TEST_BASE_URL=http://192.168.0.60:5000
+```
+
+위 설정이면 스크립트는 `http://192.168.0.60:5000/api/wrongway`로 테스트 데이터를 전송합니다.
+
+`WRONGWAY_TEST_BASE_URL`이 비어 있으면 `PUBLIC_HOST`와 `DASHBOARD_PORT`를 조합해 사용합니다.
+
+테스트 요청 대상 결정 우선순위:
+
+```txt
+1. 명령어 --base-url
+2. scripts/wrongway-test.config.json의 baseUrl
+3. .env의 WRONGWAY_TEST_BASE_URL
+4. .env의 PUBLIC_HOST + DASHBOARD_PORT
+5. http://localhost:5000
+```
+
+예시:
+
+```bash
+npm run test:wrongway-samples -- --base-url http://192.168.0.20:5000
+```
+
+위처럼 명령어에서 `--base-url`을 넘기면 `.env`와 config 파일보다 우선 적용됩니다.
+
+세부 테스트 값을 파일로 관리해야 하면 설정 파일을 생성합니다.
+
+```bash
+copy scripts\wrongway-test.config.example.json scripts\wrongway-test.config.json
+```
+
+`scripts/wrongway-test.config.json` 예시:
+
+```json
+{
+  "baseUrl": "",
+  "scenario": "all",
+  "beforeNormalCount": 10,
+  "afterNormalCount": 10,
+  "intervalMs": 1000,
+  "afterWrongwayDelayMs": 10000,
+  "normalTrackId": "script-normal-track-001",
+  "wrongwayTrackId": "script-wrongway-track-001",
+  "normalZoneId": "Z261",
+  "wrongwayZoneId": "Z327",
+  "duplicateWrongway": true
+}
+```
+
+기본 시나리오:
+
+```txt
+정주행 10회, 1초 간격
+역주행 1차 1회
+10초 대기
+정주행 10회, 1초 간격
+```
+
+명령어 옵션으로 임시 덮어쓰기:
+
+```bash
+npm run test:wrongway-samples -- --base-url http://서버IP:5000 --before-normal-count 30 --after-normal-count 30
+```
+
+다른 노트북 또는 내부망 서버로 한 번만 전송:
+
+```bash
+npm run test:wrongway-samples -- http://서버IP:5000
+```
+
+정주행만 전송:
+
+```bash
+npm run test:wrongway-samples -- --scenario normal --normal-count 60
+```
+
+역주행 1차만 전송:
+
+```bash
+npm run test:wrongway-samples -- --scenario wrongway --wrongway-track-id laptop-wrongway-001
+```
+
+사용 가능한 옵션:
+
+```txt
+--base-url URL
+--scenario all|normal|wrongway
+--normal-count N
+--before-normal-count N
+--after-normal-count N
+--interval-ms N
+--after-wrongway-delay-ms N
+--normal-track-id ID
+--wrongway-track-id ID
+--normal-zone-id ID
+--wrongway-zone-id ID
+--no-duplicate-wrongway
+```
+
+주의:
+
+- `scripts/wrongway-test.config.json`은 로컬 테스트용 파일이라 Git에 올리지 않습니다.
+- 공유용 기본 형식은 `scripts/wrongway-test.config.example.json`만 수정합니다.
+
+스크립트 동작:
+
+- 정주행 데이터 10회 전송
+- 각 정주행 데이터는 1초 간격으로 전송
+- 같은 `track_id` 기준으로 `VehicleTrack` upsert 확인
+- 역주행 1차 데이터 1회 전송
+- 기본값에서는 같은 역주행 1차 데이터 재전송으로 중복 방지 확인
+- 역주행 이후 10초 대기 후 정주행 데이터 10회 재전송
+
+DBeaver에서 확인할 테이블:
+
+```sql
+SELECT * FROM vehicle_tracks;
+SELECT * FROM traffic_events;
+SELECT * FROM event_logs;
+```
+
 ## 컨테이너 관리
 
 백그라운드 실행:

--- a/dashboard/server/src/domains/wrongway/wrongway.controller.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.controller.js
@@ -43,8 +43,51 @@ function getWrongWayTestPayloads(req, res) {
   res.json(wrongwayService.getTestPayloads(`${protocol}://${host}`));
 }
 
+async function sendNormalDrivingTest(req, res) {
+  try {
+    const result = await wrongwayService.sendNormalDrivingTestPayload(req.body || {});
+    res.json(result);
+  } catch (error) {
+    res.status(error.statusCode || 500).json({
+      ok: false,
+      message: error.message || "정주행 테스트 데이터 전송 중 오류가 발생했습니다.",
+      details: error.details,
+    });
+  }
+}
+
+function startNormalDrivingStream(req, res) {
+  res.json(wrongwayService.startNormalDrivingStream(req.body || {}));
+}
+
+function stopNormalDrivingStream(req, res) {
+  res.json(wrongwayService.stopNormalDrivingStream());
+}
+
+function getNormalDrivingStreamStatus(req, res) {
+  res.json(wrongwayService.getNormalStreamStatus());
+}
+
+async function sendWrongWayLevel1Test(req, res) {
+  try {
+    const result = await wrongwayService.sendWrongWayLevel1TestPayload(req.body || {});
+    res.status(result.result?.stored ? 201 : 200).json(result);
+  } catch (error) {
+    res.status(error.statusCode || 500).json({
+      ok: false,
+      message: error.message || "역주행 1차 테스트 데이터 전송 중 오류가 발생했습니다.",
+      details: error.details,
+    });
+  }
+}
+
 module.exports = {
   receiveWrongWay,
   getWrongWayHistory,
   getWrongWayTestPayloads,
+  getNormalDrivingStreamStatus,
+  sendNormalDrivingTest,
+  sendWrongWayLevel1Test,
+  startNormalDrivingStream,
+  stopNormalDrivingStream,
 };

--- a/dashboard/server/src/domains/wrongway/wrongway.routes.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.routes.js
@@ -6,5 +6,10 @@ const router = express.Router();
 router.post("/wrongway", controller.receiveWrongWay);
 router.get("/wrongway/history", controller.getWrongWayHistory);
 router.get("/wrongway/test-payloads", controller.getWrongWayTestPayloads);
+router.post("/wrongway/test/normal", controller.sendNormalDrivingTest);
+router.post("/wrongway/test/normal-stream/start", controller.startNormalDrivingStream);
+router.post("/wrongway/test/normal-stream/stop", controller.stopNormalDrivingStream);
+router.get("/wrongway/test/normal-stream/status", controller.getNormalDrivingStreamStatus);
+router.post("/wrongway/test/wrong-way-level-1", controller.sendWrongWayLevel1Test);
 
 module.exports = router;

--- a/dashboard/server/src/domains/wrongway/wrongway.service.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.service.js
@@ -5,6 +5,19 @@ const { adaptLidarHttpPayload } = require("../external-ingest/adapters/lidarHttp
 
 const WRONGWAY_LEVEL_1 = "wrong-way-level-1";
 const NORMAL_DRIVING = "normal-driving";
+const NORMAL_STREAM_INTERVAL_MS = 1000;
+
+let normalStreamTimer = null;
+let normalStreamState = {
+  running: false,
+  startedAt: null,
+  stoppedAt: null,
+  sentCount: 0,
+  lastResult: null,
+  lastError: null,
+  trackId: null,
+  zoneId: null,
+};
 
 function createHttpError(statusCode, message, details) {
   const error = new Error(message);
@@ -18,6 +31,51 @@ function toDateOrNull(value) {
 
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toKstIsoString(date = new Date()) {
+  // 라이다 PC 예시가 +09:00 KST ISO 문자열이라 테스트 payload도 같은 형태로 맞춘다.
+  const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return kstDate.toISOString().replace("Z", "+09:00");
+}
+
+function createNormalDrivingPayload(options = {}) {
+  // 정주행 테스트 payload는 같은 track_id로 반복 전송해 VehicleTrack upsert를 확인하는 용도다.
+  const sequence = Number(options.sequence || 0);
+  return {
+    type: NORMAL_DRIVING,
+    warning_level: 0,
+    timestamp: toKstIsoString(),
+    confidence: 1.0,
+    zone_id: options.zoneId || options.zone_id || "Z261",
+    track_id: options.trackId || options.track_id || "test-normal-track-001",
+    message: "정주행",
+    speed_ms: 0.5 + sequence * 0.05,
+    speed_kmh: (0.5 + sequence * 0.05) * 3.6,
+    object_class: 1,
+    description: "Normal",
+    consecutive_count: 0,
+    is_confirmed: false,
+  };
+}
+
+function createWrongWayLevel1Payload(options = {}) {
+  // 역주행 1차 테스트 payload는 TrafficEvent 저장과 중복 방지 로직을 확인하는 용도다.
+  return {
+    type: WRONGWAY_LEVEL_1,
+    warning_level: 1,
+    timestamp: toKstIsoString(),
+    confidence: 0.95,
+    zone_id: options.zoneId || options.zone_id || "Z327",
+    track_id: options.trackId || options.track_id || "test-wrongway-track-001",
+    message: "역주행 1차 감지",
+    speed_ms: 2.835765050970876,
+    speed_kmh: 10.208754183495154,
+    object_class: 6,
+    description: "Wrong-way driving detected (Heading and Path Confirmed)",
+    consecutive_count: 3,
+    is_confirmed: true,
+  };
 }
 
 async function findZoneByExternalCode(externalZoneId) {
@@ -252,42 +310,19 @@ async function receiveWrongWayPayload(payload = {}) {
 function getTestPayloads(baseUrl = "http://localhost:5000") {
   const endpoint = `${baseUrl.replace(/\/+$/, "")}/api/wrongway`;
 
-  const normalDriving = {
-    type: "normal-driving",
-    warning_level: 0,
-    timestamp: "2026-01-13T14:43:53.860089+09:00",
-    confidence: 1.0,
-    zone_id: "Z261",
-    track_id: "54750000-0000-0000-0000-000000000000",
-    message: "정주행",
-    speed_ms: 0.5792374909226594,
-    speed_kmh: 2.085254967321574,
-    object_class: 1,
-    description: "Normal",
-    consecutive_count: 0,
-    is_confirmed: false,
-  };
-
-  const wrongWayLevel1 = {
-    type: "wrong-way-level-1",
-    warning_level: 1,
-    timestamp: "2026-01-13T14:43:54.360258+09:00",
-    confidence: 0.95,
-    zone_id: "Z327",
-    track_id: "81760000-0000-0000-0000-000000000000",
-    message: "역주행 1차 감지",
-    speed_ms: 2.835765050970876,
-    speed_kmh: 10.208754183495154,
-    object_class: 6,
-    description: "Wrong-way driving detected (Heading and Path Confirmed)",
-    consecutive_count: 3,
-    is_confirmed: true,
-  };
+  const normalDriving = createNormalDrivingPayload();
+  const wrongWayLevel1 = createWrongWayLevel1Payload();
 
   return {
     ok: true,
     endpoint,
     note: "다른 PC에서는 localhost 대신 대시보드 서버 PC의 내부망 IP를 사용합니다.",
+    testApis: {
+      startNormalStream: `${baseUrl.replace(/\/+$/, "")}/api/wrongway/test/normal-stream/start`,
+      stopNormalStream: `${baseUrl.replace(/\/+$/, "")}/api/wrongway/test/normal-stream/stop`,
+      normalStreamStatus: `${baseUrl.replace(/\/+$/, "")}/api/wrongway/test/normal-stream/status`,
+      sendWrongWayLevel1: `${baseUrl.replace(/\/+$/, "")}/api/wrongway/test/wrong-way-level-1`,
+    },
     payloads: {
       normalDriving,
       wrongWayLevel1,
@@ -295,7 +330,104 @@ function getTestPayloads(baseUrl = "http://localhost:5000") {
   };
 }
 
+async function sendNormalDrivingTestPayload(options = {}) {
+  const payload = createNormalDrivingPayload(options);
+  const result = await receiveWrongWayPayload(payload);
+  return { ok: true, payload, result };
+}
+
+async function sendWrongWayLevel1TestPayload(options = {}) {
+  const payload = createWrongWayLevel1Payload(options);
+  const result = await receiveWrongWayPayload(payload);
+  return { ok: true, payload, result };
+}
+
+function getNormalStreamStatus() {
+  return {
+    ok: true,
+    ...normalStreamState,
+    intervalMs: NORMAL_STREAM_INTERVAL_MS,
+  };
+}
+
+function stopNormalDrivingStream() {
+  if (normalStreamTimer) {
+    clearInterval(normalStreamTimer);
+    normalStreamTimer = null;
+  }
+
+  normalStreamState = {
+    ...normalStreamState,
+    running: false,
+    stoppedAt: new Date().toISOString(),
+  };
+
+  return getNormalStreamStatus();
+}
+
+async function tickNormalDrivingStream(options = {}) {
+  const sequence = normalStreamState.sentCount + 1;
+  const payload = createNormalDrivingPayload({
+    ...options,
+    sequence,
+    trackId: normalStreamState.trackId,
+    zoneId: normalStreamState.zoneId,
+  });
+
+  try {
+    const result = await receiveWrongWayPayload(payload);
+    normalStreamState = {
+      ...normalStreamState,
+      sentCount: sequence,
+      lastResult: result,
+      lastError: null,
+    };
+  } catch (error) {
+    normalStreamState = {
+      ...normalStreamState,
+      lastError: {
+        message: error.message,
+        details: error.details,
+      },
+    };
+    logger.error("normal driving stream tick failed", { error });
+  }
+}
+
+function startNormalDrivingStream(options = {}) {
+  if (normalStreamTimer) {
+    return {
+      ...getNormalStreamStatus(),
+      message: "정주행 테스트 스트림이 이미 실행 중입니다.",
+    };
+  }
+
+  normalStreamState = {
+    running: true,
+    startedAt: new Date().toISOString(),
+    stoppedAt: null,
+    sentCount: 0,
+    lastResult: null,
+    lastError: null,
+    trackId: options.trackId || options.track_id || "test-normal-track-001",
+    zoneId: options.zoneId || options.zone_id || "Z261",
+  };
+
+  // 시작 버튼을 누른 직후 한 번 전송하고, 이후 1초 간격으로 같은 track_id를 반복 전송한다.
+  tickNormalDrivingStream(options);
+  normalStreamTimer = setInterval(() => {
+    tickNormalDrivingStream(options);
+  }, NORMAL_STREAM_INTERVAL_MS);
+
+  return getNormalStreamStatus();
+}
+
 module.exports = {
-  receiveWrongWayPayload,
   getTestPayloads,
+  getNormalStreamStatus,
+  receiveWrongWayPayload,
+  sendNormalDrivingTestPayload,
+  sendWrongWayLevel1TestPayload,
+  startNormalDrivingStream,
+  stopNormalDrivingStream,
 };

--- a/dashboard/server/src/swagger.js
+++ b/dashboard/server/src/swagger.js
@@ -287,7 +287,9 @@ const swaggerSpec = {
     "/api/wrongway": {
       post: {
         tags: ["Wrongway"],
-        summary: "역주행 감지 이벤트 수신",
+        summary: "라이다 정주행/역주행 이벤트 수신",
+        description:
+          "라이다 PC가 보내는 공식 수신 API입니다. normal-driving은 VehicleTrack upsert로 최신 상태만 갱신하고, wrong-way-level-1은 TrafficEvent/EventLog에 저장합니다.",
         requestBody: {
           required: false,
           content: {
@@ -302,6 +304,142 @@ const swaggerSpec = {
             content: {
               "application/json": {
                 schema: { $ref: "#/components/schemas/OkResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/wrongway/test-payloads": {
+      get: {
+        tags: ["Wrongway"],
+        summary: "라이다 테스트 payload와 API URL 조회",
+        description:
+          "정주행/역주행 테스트 payload와 Swagger 테스트용 API URL을 한 번에 확인합니다.",
+        responses: {
+          200: {
+            description: "테스트 payload 조회 성공",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WrongwayTestPayloadsResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/wrongway/test/normal": {
+      post: {
+        tags: ["Wrongway"],
+        summary: "정주행 테스트 데이터 1회 전송",
+        description:
+          "정주행 payload를 1회 생성해 기존 /api/wrongway 처리 흐름으로 보냅니다. VehicleTrack upsert 동작을 단건으로 확인할 때 사용합니다.",
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/WrongwayTestOptions" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "정주행 테스트 데이터 처리 완료",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WrongwayTestSendResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/wrongway/test/normal-stream/start": {
+      post: {
+        tags: ["Wrongway"],
+        summary: "정주행 테스트 데이터 1초 간격 전송 시작",
+        description:
+          "서버 내부에서 1초마다 normal-driving payload를 생성해 기존 /api/wrongway 처리 흐름으로 보냅니다. 같은 track_id를 반복 전송해 VehicleTrack upsert를 확인합니다.",
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/WrongwayTestOptions" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "정주행 테스트 스트림 시작 또는 이미 실행 중",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/NormalDrivingStreamStatus" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/wrongway/test/normal-stream/stop": {
+      post: {
+        tags: ["Wrongway"],
+        summary: "정주행 테스트 데이터 1초 간격 전송 중지",
+        responses: {
+          200: {
+            description: "정주행 테스트 스트림 중지",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/NormalDrivingStreamStatus" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/wrongway/test/normal-stream/status": {
+      get: {
+        tags: ["Wrongway"],
+        summary: "정주행 테스트 스트림 상태 조회",
+        responses: {
+          200: {
+            description: "정주행 테스트 스트림 상태",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/NormalDrivingStreamStatus" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/wrongway/test/wrong-way-level-1": {
+      post: {
+        tags: ["Wrongway"],
+        summary: "역주행 1차 테스트 데이터 1회 전송",
+        description:
+          "역주행 1차 payload를 1회 생성해 기존 /api/wrongway 처리 흐름으로 보냅니다. TrafficEvent 저장과 동일 track_id 중복 방지를 확인합니다.",
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/WrongwayTestOptions" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "역주행 1차 테스트 데이터 처리 완료 또는 중복 처리",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WrongwayTestSendResponse" },
+              },
+            },
+          },
+          201: {
+            description: "역주행 1차 이벤트 신규 저장",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WrongwayTestSendResponse" },
               },
             },
           },
@@ -752,17 +890,104 @@ const swaggerSpec = {
       },
       WrongwayRequest: {
         type: "object",
+        required: ["type", "track_id"],
         properties: {
-          id: { type: "string", example: "evt-001" },
-          stage: { type: "integer", example: 1 },
-          message: { type: "string", example: "구역: 출구-B" },
-          timestamp: { type: "string", format: "date-time" },
-          zone_id: { type: "string", example: "EXIT-B" },
-          track_id: { type: "string", example: "track-12" },
-          confidence: { type: "number", example: 0.92 },
-          video_ts_ms: { type: "integer", example: 12345 },
-          device_id: { type: "string", example: "LIDAR-01" },
-          serial_no: { type: "string", example: "SN-001" },
+          type: {
+            type: "string",
+            enum: ["normal-driving", "wrong-way-level-1", "wrong-way-level-2", "situation-ended"],
+            example: "normal-driving",
+          },
+          warning_level: { type: "integer", example: 0 },
+          timestamp: { type: "string", example: "2026-01-13T14:43:53.860089+09:00" },
+          confidence: { type: "number", example: 1.0 },
+          zone_id: { type: "string", example: "Z261" },
+          track_id: { type: "string", example: "test-normal-track-001" },
+          message: { type: "string", example: "정주행" },
+          speed_ms: { type: "number", example: 0.5792374909226594 },
+          speed_kmh: { type: "number", example: 2.085254967321574 },
+          object_class: { type: "integer", example: 1 },
+          description: { type: "string", example: "Normal" },
+          consecutive_count: { type: "integer", example: 0 },
+          is_confirmed: { type: "boolean", example: false },
+        },
+      },
+      WrongwayTestOptions: {
+        type: "object",
+        properties: {
+          trackId: {
+            type: "string",
+            example: "test-normal-track-001",
+            description: "테스트용 track_id를 직접 지정할 때 사용합니다.",
+          },
+          zoneId: {
+            type: "string",
+            example: "Z261",
+            description: "테스트용 zone_id를 직접 지정할 때 사용합니다.",
+          },
+        },
+      },
+      WrongwayReceiveResult: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          stored: { type: "boolean", example: false },
+          duplicated: { type: "boolean", example: false },
+          reason: { type: "string", example: "TRACK_UPDATED" },
+          eventId: { type: "string", nullable: true, example: null },
+          trackId: { type: "string", example: "test-normal-track-001" },
+          type: { type: "string", example: "normal-driving" },
+          warningLevel: { type: "integer", example: 0 },
+          normalMovingVehicleCount: { type: "integer", example: 1 },
+          receivedAt: { type: "string", format: "date-time" },
+        },
+      },
+      WrongwayTestSendResponse: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          payload: { $ref: "#/components/schemas/WrongwayRequest" },
+          result: { $ref: "#/components/schemas/WrongwayReceiveResult" },
+        },
+      },
+      WrongwayTestPayloadsResponse: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          endpoint: { type: "string", example: "http://localhost:5000/api/wrongway" },
+          note: { type: "string" },
+          testApis: {
+            type: "object",
+            additionalProperties: { type: "string" },
+          },
+          payloads: {
+            type: "object",
+            properties: {
+              normalDriving: { $ref: "#/components/schemas/WrongwayRequest" },
+              wrongWayLevel1: { $ref: "#/components/schemas/WrongwayRequest" },
+            },
+          },
+        },
+      },
+      NormalDrivingStreamStatus: {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", example: true },
+          running: { type: "boolean", example: true },
+          startedAt: { type: "string", format: "date-time", nullable: true },
+          stoppedAt: { type: "string", format: "date-time", nullable: true },
+          sentCount: { type: "integer", example: 3 },
+          intervalMs: { type: "integer", example: 1000 },
+          trackId: { type: "string", example: "test-normal-track-001" },
+          zoneId: { type: "string", example: "Z261" },
+          lastResult: {
+            nullable: true,
+            oneOf: [{ $ref: "#/components/schemas/WrongwayReceiveResult" }],
+          },
+          lastError: {
+            type: "object",
+            nullable: true,
+            additionalProperties: true,
+          },
         },
       },
       ExternalEvent: {

--- a/docs/specs/lidar-dashboard-payload.md
+++ b/docs/specs/lidar-dashboard-payload.md
@@ -1,29 +1,53 @@
 # 라이다 PC -> 대시보드 payload 규격
 
-이 문서는 라이다 PC가 대시보드로 전송하는 HTTP JSON 데이터의 현재 기준입니다.
+이 문서는 라이다 PC가 대시보드 백엔드로 전송하는 HTTP JSON 데이터의 현재 개발 기준입니다.
 
 ## 기본 연동 정보
 
-- 방향: 라이다 PC -> 대시보드
+- 방향: 라이다 PC -> 대시보드 백엔드
 - 방식: HTTP POST
 - Content-Type: `application/json`
 - endpoint: `/api/wrongway`
+- 정주행 데이터: 차량이 감지 범위에 있는 동안 1초 간격 전송 가능
+- 역주행 1차 데이터: 상황 발생 시 1회 전송 기준
 
-## 현재 예상 payload
+## 정주행 payload 예시
 
 ```json
 {
-  "type": "wrong-way",
-  "timestamp": "2026-06-19T15:50:11.908091+09:00",
+  "type": "normal-driving",
+  "warning_level": 0,
+  "timestamp": "2026-01-13T14:43:53.860089+09:00",
+  "confidence": 1.0,
+  "zone_id": "Z261",
+  "track_id": "54750000-0000-0000-0000-000000000000",
+  "message": "정주행",
+  "speed_ms": 0.5792374909226594,
+  "speed_kmh": 2.085254967321574,
+  "object_class": 1,
+  "description": "Normal",
+  "consecutive_count": 0,
+  "is_confirmed": false
+}
+```
+
+## 역주행 1차 payload 예시
+
+```json
+{
+  "type": "wrong-way-level-1",
+  "warning_level": 1,
+  "timestamp": "2026-01-13T14:43:54.360258+09:00",
   "confidence": 0.95,
   "zone_id": "Z327",
-  "track_id": "grid_16648_16670",
-  "message": "Vehicle detected (replay)",
-  "speed_ms": 2.9173103921382224,
-  "speed_kmh": 10.5023174116976,
+  "track_id": "81760000-0000-0000-0000-000000000000",
+  "message": "역주행 1차 감지",
+  "speed_ms": 2.835765050970876,
+  "speed_kmh": 10.208754183495154,
   "object_class": 6,
-  "uuid": "82760000",
-  "description": "Wrong-way driving detected (Heading and Path Confirmed)"
+  "description": "Wrong-way driving detected (Heading and Path Confirmed)",
+  "consecutive_count": 3,
+  "is_confirmed": true
 }
 ```
 
@@ -31,31 +55,55 @@
 
 | 필드 | 논리 이름 | 설명 |
 | --- | --- | --- |
-| `type` | 이벤트 유형 | 현재는 `wrong-way`가 전달될 것으로 예상합니다. |
+| `type` | 이벤트 유형 | `normal-driving`, `wrong-way-level-1` 기준으로 처리합니다. |
+| `warning_level` | 경고 단계 | 정주행 0, 역주행 1차 1, 역주행 2차 2 기준입니다. |
 | `timestamp` | 이벤트 발생 시간 | KST ISO 문자열 형식을 기대합니다. |
-| `confidence` | 감지 신뢰도 | 예시상 0~1 범위로 보이며 산정 기준은 추가 확인 중입니다. |
-| `zone_id` | 감지 구역 ID | lanelet ID를 `Z01`, `Z327` 형태로 변환한 값입니다. |
-| `track_id` | 객체/트래킹 ID | `stable_object_id` 기반 값으로 이해하고 있습니다. |
-| `message` | 이벤트 요약 메시지 | 현재는 `"Vehicle detected (replay)"` 고정값일 수 있습니다. |
-| `speed_ms` | 속도(m/s) | 추가 제공 가능성이 있는 필드입니다. |
-| `speed_kmh` | 속도(km/h) | 추가 제공 가능성이 있는 필드입니다. |
-| `object_class` | 객체 종류 코드 | 코드표에서 4번 값은 추가 확인 중입니다. |
-| `uuid` | 객체 UUID | 라이다 PC 내부 객체 UUID입니다. |
+| `confidence` | 감지 신뢰도 | 예시상 0~1 범위입니다. 판단 기준으로 쓰지 않고 표시/저장합니다. |
+| `zone_id` | 외부 감지 구역 ID | 라이다 PC의 lanelet ID 기반 구역 코드입니다. |
+| `track_id` | 객체/트래킹 ID | 동일 차량 중복 처리와 `VehicleTrack` upsert 기준입니다. |
+| `message` | 이벤트 요약 메시지 | 화면 표시와 로그 확인에 사용합니다. |
+| `speed_ms` | 속도(m/s) | optional 값입니다. |
+| `speed_kmh` | 속도(km/h) | optional 값입니다. |
+| `object_class` | 객체 종류 코드 | 코드표의 4번 값은 추가 확인이 필요합니다. |
 | `description` | 감지 상세 설명 | 감지 사유 또는 상태 설명입니다. |
+| `consecutive_count` | 연속 감지 횟수 | 라이다 PC 판단 로직 확인용 값입니다. |
+| `is_confirmed` | 확정 여부 | 라이다 PC가 판단한 감지 확정 여부입니다. |
+
+## 현재 처리 기준
+
+- `normal-driving`
+  - 1초 간격으로 반복 수신될 수 있습니다.
+  - 매번 이벤트로 저장하지 않습니다.
+  - 같은 `track_id` 기준으로 `VehicleTrack`을 upsert하여 최신 상태만 갱신합니다.
+
+- `wrong-way-level-1`
+  - `TrafficEvent`와 `EventLog`에 저장합니다.
+  - 같은 `track_id`와 같은 경고 단계가 이미 저장되어 있으면 중복 저장하지 않습니다.
+
+- `wrong-way-level-2`, `situation-ended`
+  - adapter에서 타입 수신은 가능하지만 실제 저장/상태 변경 로직은 후속 개발 범위입니다.
 
 ## 현재 제외한 필드
 
+- `uuid`
+  - 최신 전달 규격에서 제외된 것으로 보고 사용하지 않습니다.
 - `normal_moving_vehicle_count`
-  - 역주행 이벤트에만 포함되면 정상 통과 차량 수를 안정적으로 집계하기 어렵습니다.
-  - 정주행 이벤트를 별도 `type`으로 받을 수 있는지 확인 요청 중입니다.
+  - 라이다 PC가 보내는 값에 의존하지 않고 대시보드 DB 기준으로 계산합니다.
 
-## 추가 확인 중인 사항
+## Swagger 테스트 API
 
-- `object_class` 코드표의 4번 값
-- `confidence` 산정 기준
-- 정주행 이벤트 제공 가능 여부
-- 1차 감지, 2차 감지, 상황 종료를 구분할 수 있는 `type` 또는 `description` 제공 가능 여부
-- `consecutive_count`, `is_confirmed`의 의미
+- `GET /api/wrongway/test-payloads`
+  - 현재 테스트 payload와 테스트 URL 목록을 조회합니다.
+- `POST /api/wrongway/test/normal`
+  - 정주행 payload를 1회 생성해 기존 `/api/wrongway` 처리 흐름으로 보냅니다.
+- `POST /api/wrongway/test/normal-stream/start`
+  - 정주행 payload를 1초 간격으로 반복 처리합니다.
+- `POST /api/wrongway/test/normal-stream/stop`
+  - 정주행 반복 처리를 중지합니다.
+- `GET /api/wrongway/test/normal-stream/status`
+  - 정주행 반복 처리 상태를 조회합니다.
+- `POST /api/wrongway/test/wrong-way-level-1`
+  - 역주행 1차 payload를 1회 생성해 기존 `/api/wrongway` 처리 흐름으로 보냅니다.
 
 ## 제공되지 않는 것으로 보는 항목
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:web": "npm --prefix dashboard/dashboard-web run build",
     "check:server": "node dashboard/server/scripts/check-syntax.js",
     "ci": "npm run build:web && npm run check:server",
+    "test:wrongway-samples": "node scripts/send-wrongway-samples.js",
     "setup:demo": "python -m venv dashboard/demo-server/venv && \"dashboard\\demo-server\\venv\\Scripts\\python.exe\" -m pip install -r dashboard/demo-server/requirements.txt"
   }
 }

--- a/scripts/send-wrongway-samples.js
+++ b/scripts/send-wrongway-samples.js
@@ -1,0 +1,344 @@
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_BASE_URL = "http://localhost:5000";
+const CONFIG_PATH = path.join(__dirname, "wrongway-test.config.json");
+const ENV_PATH = path.resolve(__dirname, "../.env");
+
+function loadRootEnv() {
+  // 테스트 스크립트는 서버 코드 밖에서 실행되므로 루트 .env를 직접 읽어 기본 목적지를 맞춘다.
+  // dotenv 의존성을 새로 쓰지 않고, KEY=VALUE 형태만 가볍게 읽는다.
+  if (!fs.existsSync(ENV_PATH)) return;
+
+  const lines = fs.readFileSync(ENV_PATH, "utf-8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim().replace(/^["']|["']$/g, "");
+
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadRootEnv();
+
+function getDefaultBaseUrl() {
+  // 기본 목적지는 테스트 스크립트 전용 Base URL을 우선 사용한다.
+  // 서버 실행용 PUBLIC_HOST와 "요청을 보낼 대상"은 다를 수 있어 값을 분리한다.
+  if (process.env.WRONGWAY_TEST_BASE_URL) return process.env.WRONGWAY_TEST_BASE_URL;
+
+  const host = process.env.PUBLIC_HOST || "localhost";
+  const port = process.env.DASHBOARD_PORT || "5000";
+  return `http://${host}:${port}`;
+}
+
+function readConfigFile() {
+  // 현장/내부망 테스트 값은 매번 긴 명령어로 쓰기 번거로워서 JSON 파일로 받을 수 있게 한다.
+  // 실제 config 파일은 IP가 들어갈 수 있으므로 Git에 올리지 않고, example 파일만 공유한다.
+  if (!fs.existsSync(CONFIG_PATH)) return {};
+
+  const rawConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
+  return JSON.parse(rawConfig);
+}
+
+function createDefaultArgs() {
+  return {
+    baseUrl: process.env.WRONGWAY_BASE_URL || getDefaultBaseUrl() || DEFAULT_BASE_URL,
+    scenario: "all",
+    beforeNormalCount: 10,
+    afterNormalCount: 10,
+    intervalMs: 1000,
+    afterWrongwayDelayMs: 10000,
+    normalTrackId: "script-normal-track-001",
+    wrongwayTrackId: "script-wrongway-track-001",
+    normalZoneId: "Z261",
+    wrongwayZoneId: "Z327",
+    duplicateWrongway: true,
+    help: false,
+  };
+}
+
+function normalizeArgs(args) {
+  const normalized = { ...args };
+
+  normalized.baseUrl = String(normalized.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
+  normalized.beforeNormalCount = Number.isFinite(Number(normalized.beforeNormalCount)) && Number(normalized.beforeNormalCount) > 0
+    ? Math.floor(Number(normalized.beforeNormalCount))
+    : 10;
+  normalized.afterNormalCount = Number.isFinite(Number(normalized.afterNormalCount)) && Number(normalized.afterNormalCount) > 0
+    ? Math.floor(Number(normalized.afterNormalCount))
+    : 10;
+  normalized.intervalMs = Number.isFinite(Number(normalized.intervalMs)) && Number(normalized.intervalMs) >= 0
+    ? Math.floor(Number(normalized.intervalMs))
+    : 1000;
+  normalized.afterWrongwayDelayMs = Number.isFinite(Number(normalized.afterWrongwayDelayMs)) && Number(normalized.afterWrongwayDelayMs) >= 0
+    ? Math.floor(Number(normalized.afterWrongwayDelayMs))
+    : 10000;
+  normalized.duplicateWrongway = normalized.duplicateWrongway !== false;
+
+  return normalized;
+}
+
+function parseArgs(argv) {
+  const fileConfig = readConfigFile();
+  const args = {
+    ...createDefaultArgs(),
+    ...fileConfig,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+      continue;
+    }
+
+    if (token === "--base-url") {
+      args.baseUrl = next || args.baseUrl;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--scenario") {
+      args.scenario = next || args.scenario;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--normal-count") {
+      args.beforeNormalCount = Number(next || args.beforeNormalCount);
+      args.afterNormalCount = Number(next || args.afterNormalCount);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--before-normal-count") {
+      args.beforeNormalCount = Number(next || args.beforeNormalCount);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--after-normal-count") {
+      args.afterNormalCount = Number(next || args.afterNormalCount);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--interval-ms") {
+      args.intervalMs = Number(next || args.intervalMs);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--after-wrongway-delay-ms") {
+      args.afterWrongwayDelayMs = Number(next || args.afterWrongwayDelayMs);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--normal-track-id") {
+      args.normalTrackId = next || args.normalTrackId;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--wrongway-track-id") {
+      args.wrongwayTrackId = next || args.wrongwayTrackId;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--normal-zone-id") {
+      args.normalZoneId = next || args.normalZoneId;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--wrongway-zone-id") {
+      args.wrongwayZoneId = next || args.wrongwayZoneId;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--no-duplicate-wrongway") {
+      args.duplicateWrongway = false;
+      continue;
+    }
+
+    if (!token.startsWith("--")) {
+      // 기존 사용법인 `npm run test:wrongway-samples -- http://서버IP:5000`도 계속 지원한다.
+      args.baseUrl = token;
+    }
+  }
+
+  return normalizeArgs(args);
+}
+
+function printHelp() {
+  console.log(`
+wrongway sample sender
+
+사용 예시:
+  npm run test:wrongway-samples
+  copy scripts\\wrongway-test.config.example.json scripts\\wrongway-test.config.json
+  npm run test:wrongway-samples -- http://192.168.0.20:5000
+  npm run test:wrongway-samples -- --base-url http://192.168.0.20:5000 --before-normal-count 30 --after-normal-count 30
+  npm run test:wrongway-samples -- --scenario normal --normal-count 60
+  npm run test:wrongway-samples -- --scenario wrongway --wrongway-track-id laptop-wrongway-001
+
+옵션:
+  --base-url URL               요청을 보낼 백엔드 주소
+  --scenario all|normal|wrongway
+  --normal-count N             역주행 전/후 정주행 전송 횟수를 같은 값으로 설정
+  --before-normal-count N      역주행 전 정주행 전송 횟수
+  --after-normal-count N       역주행 후 정주행 전송 횟수
+  --interval-ms N              정주행 전송 간격(ms)
+  --after-wrongway-delay-ms N  역주행 후 정주행 재개 전 대기 시간(ms)
+  --normal-track-id ID         정주행 track_id
+  --wrongway-track-id ID       역주행 track_id
+  --normal-zone-id ID          정주행 zone_id
+  --wrongway-zone-id ID        역주행 zone_id
+  --no-duplicate-wrongway      역주행 중복 전송 생략
+
+설정 파일:
+  scripts/wrongway-test.config.json 값이 있으면 기본값으로 사용한다.
+  설정 파일이 없으면 루트 .env의 WRONGWAY_TEST_BASE_URL을 우선 사용한다.
+  명령어 옵션을 함께 쓰면 설정 파일 값보다 명령어 옵션이 우선한다.
+`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function toKstIsoString(date = new Date()) {
+  // 라이다 PC 예시와 같은 +09:00 형태로 테스트 시간을 만든다.
+  const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return kstDate.toISOString().replace("Z", "+09:00");
+}
+
+function createNormalPayload(sequence, args) {
+  // 같은 track_id를 반복 전송해서 VehicleTrack upsert가 update로 동작하는지 확인한다.
+  const speedMs = 0.5 + sequence * 0.05;
+  return {
+    type: "normal-driving",
+    warning_level: 0,
+    timestamp: toKstIsoString(),
+    confidence: 1.0,
+    zone_id: args.normalZoneId,
+    track_id: args.normalTrackId,
+    message: "정주행",
+    speed_ms: speedMs,
+    speed_kmh: speedMs * 3.6,
+    object_class: 1,
+    description: "Normal",
+    consecutive_count: 0,
+    is_confirmed: false,
+  };
+}
+
+function createWrongWayPayload(args) {
+  // 같은 payload를 두 번 보내면 두 번째 요청은 중복 이벤트로 처리되어야 한다.
+  return {
+    type: "wrong-way-level-1",
+    warning_level: 1,
+    timestamp: toKstIsoString(),
+    confidence: 0.95,
+    zone_id: args.wrongwayZoneId,
+    track_id: args.wrongwayTrackId,
+    message: "역주행 1차 감지",
+    speed_ms: 2.835765050970876,
+    speed_kmh: 10.208754183495154,
+    object_class: 6,
+    description: "Wrong-way driving detected (Heading and Path Confirmed)",
+    consecutive_count: 3,
+    is_confirmed: true,
+  };
+}
+
+async function postPayload(endpoint, label, payload) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const result = await response.json();
+  console.log(`[${label}] HTTP ${response.status}`);
+  console.log(JSON.stringify(result, null, 2));
+  return result;
+}
+
+async function sendNormalSequence(endpoint, args, count, labelPrefix) {
+  for (let index = 1; index <= count; index += 1) {
+    await postPayload(
+      endpoint,
+      `${labelPrefix} normal-driving ${index}/${count}`,
+      createNormalPayload(index, args),
+    );
+
+    if (index < count) await sleep(args.intervalMs);
+  }
+}
+
+async function sendWrongwaySequence(endpoint, args) {
+  const wrongWayPayload = createWrongWayPayload(args);
+  await postPayload(endpoint, "wrong-way-level-1 first", wrongWayPayload);
+
+  if (args.duplicateWrongway) {
+    await postPayload(endpoint, "wrong-way-level-1 duplicated", wrongWayPayload);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const endpoint = `${args.baseUrl}/api/wrongway`;
+  console.log(`wrongway sample sender -> ${endpoint}`);
+  console.log(`configFile=${fs.existsSync(CONFIG_PATH) ? CONFIG_PATH : "not found"}`);
+  console.log(`scenario=${args.scenario}, beforeNormalCount=${args.beforeNormalCount}, afterNormalCount=${args.afterNormalCount}`);
+  console.log(`intervalMs=${args.intervalMs}, afterWrongwayDelayMs=${args.afterWrongwayDelayMs}`);
+  console.log(`normalTrackId=${args.normalTrackId}, wrongwayTrackId=${args.wrongwayTrackId}`);
+
+  if (!["all", "normal", "wrongway"].includes(args.scenario)) {
+    throw new Error(`지원하지 않는 scenario입니다: ${args.scenario}`);
+  }
+
+  if (args.scenario === "normal") {
+    await sendNormalSequence(endpoint, args, args.beforeNormalCount, "before");
+    return;
+  }
+
+  if (args.scenario === "wrongway") {
+    await sendWrongwaySequence(endpoint, args);
+    return;
+  }
+
+  await sendNormalSequence(endpoint, args, args.beforeNormalCount, "before");
+  await sendWrongwaySequence(endpoint, args);
+
+  console.log(`waiting ${args.afterWrongwayDelayMs}ms before sending normal-driving again...`);
+  await sleep(args.afterWrongwayDelayMs);
+  await sendNormalSequence(endpoint, args, args.afterNormalCount, "after");
+}
+
+main().catch((error) => {
+  console.error("wrongway sample sender failed");
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/wrongway-test.config.example.json
+++ b/scripts/wrongway-test.config.example.json
@@ -1,0 +1,13 @@
+{
+  "baseUrl": "",
+  "scenario": "all",
+  "beforeNormalCount": 10,
+  "afterNormalCount": 10,
+  "intervalMs": 1000,
+  "afterWrongwayDelayMs": 10000,
+  "normalTrackId": "script-normal-track-001",
+  "wrongwayTrackId": "script-wrongway-track-001",
+  "normalZoneId": "Z261",
+  "wrongwayZoneId": "Z327",
+  "duplicateWrongway": true
+}


### PR DESCRIPTION
## 작업 내용

- 라이다 수신 테스트용 Swagger API를 추가했습니다.
- 정주행 테스트 데이터를 1초 간격으로 발생시키고, 기존 `/api/wrongway` 처리 흐름을 통해 `VehicleTrack` upsert를 확인할 수 있게 했습니다.
- 역주행 1차 테스트 데이터를 발생시키고 `TrafficEvent`, `EventLog` 저장 및 중복 방지 흐름을 확인할 수 있게 했습니다.
- 로컬/내부망 테스트용 `scripts/send-wrongway-samples.js`를 추가했습니다.
- 기본 테스트 시나리오를 `정주행 10회 → 역주행 1차 → 중복 역주행 1차 → 10초 대기 → 정주행 10회`로 구성했습니다.
- 최신 라이다 payload 기준으로 `docs/specs/lidar-dashboard-payload.md`를 갱신했습니다.
- README에 Swagger, 테스트 스크립트, DBeaver 확인 방법을 추가했습니다.

## 주요 API

- `GET /api/wrongway/test-payloads`
- `POST /api/wrongway/test/normal`
- `POST /api/wrongway/test/normal-stream/start`
- `POST /api/wrongway/test/normal-stream/stop`
- `GET /api/wrongway/test/normal-stream/status`
- `POST /api/wrongway/test/wrong-way-level-1`

## 검증

- `node --check scripts/send-wrongway-samples.js`
- `npm run test:wrongway-samples -- --help`
- `npm run check:server`
- `npm run ci`

## 참고

- `scripts/wrongway-test.config.json`은 로컬/현장 테스트용이라 Git에 올리지 않습니다.
- 실제 HTTP 전송은 대상 백엔드 서버와 DB가 실행된 상태에서 확인해야 합니다.
- Vite build 시 browserslist/chunk size 경고가 출력되지만 실패는 아닙니다.