### PR TITLE
refactor: 라이다 adapter 위치 정리

### DIFF
--- a/dashboard/server/src/domains/external-ingest/externalIngest.service.js
+++ b/dashboard/server/src/domains/external-ingest/externalIngest.service.js
@@ -1,7 +1,7 @@
 const { logger } = require("../../utils/logger");
 const mockLidarService = require("../mock-lidar/mockLidar.service");
 const { EXTERNAL_EVENT_SOURCE, EXTERNAL_EVENT_TYPE } = require("./externalEvent.model");
-const { adaptLidarHttpPayload } = require("./adapters/lidarHttp.adapter");
+const { adaptLidarHttpPayload } = require("../wrongway/adapters/lidarHttp.adapter");
 const { adaptControlBoardPacket } = require("./adapters/controlBoardPacket.adapter");
 
 // 최근 수신 이벤트는 DB 저장 전까지 메모리에 최대 50건만 유지한다.

--- a/dashboard/server/src/domains/wrongway/adapters/lidarHttp.adapter.js
+++ b/dashboard/server/src/domains/wrongway/adapters/lidarHttp.adapter.js
@@ -3,7 +3,7 @@ const {
   EXTERNAL_EVENT_TYPE,
   createExternalEvent,
   createRawSummary,
-} = require("../externalEvent.model");
+} = require("../../external-ingest/externalEvent.model");
 
 // 라이다 PC가 보내는 상황 type을 대시보드 내부 이벤트 타입으로 변환한다.
 // 외부 type 원문은 originalType으로 따로 보존하고, 내부 처리는 아래 표준 타입을 기준으로 한다.

--- a/dashboard/server/src/domains/wrongway/wrongway.service.js
+++ b/dashboard/server/src/domains/wrongway/wrongway.service.js
@@ -1,7 +1,7 @@
 const { prisma } = require("../../prisma/client");
 const { logger } = require("../../utils/logger");
 const mockLidarService = require("../mock-lidar/mockLidar.service");
-const { adaptLidarHttpPayload } = require("../external-ingest/adapters/lidarHttp.adapter");
+const { adaptLidarHttpPayload } = require("./adapters/lidarHttp.adapter");
 const {
   WRONGWAY_EVENT_STATUS,
   WRONGWAY_EVENT_TYPE,

--- a/docs/ai/project-context.md
+++ b/docs/ai/project-context.md
@@ -66,5 +66,7 @@
 
 - 원본 payload는 가능한 한 보존합니다.
 - 라이다 PC 데이터 해석은 adapter 계층에 격리합니다.
+- `/api/wrongway` 실제 저장 흐름의 라이다 HTTP adapter는 `domains/wrongway/adapters`에 둡니다.
+- `external-ingest`는 현장 진단, mock 수신, 통합제어보드 패킷 확인처럼 DB 저장 전 수신 상태 확인 용도로 둡니다.
 - 아직 확정되지 않은 필드는 확정된 것처럼 구현하지 않습니다.
 - 통합제어보드 제어 기능은 별도 프로토콜 정의 후 진행합니다.

--- a/docs/conventions/backend.md
+++ b/docs/conventions/backend.md
@@ -59,7 +59,19 @@ domains/wrongway
 - wrongway.routes.js
 - wrongway.controller.js
 - wrongway.service.js
+- adapters
+  - lidarHttp.adapter.js
+- wrongway.dto.js
+- wrongway.constants.js
 ```
+
+## DTO와 adapter 기준
+
+- `dto`: 컨트롤러가 받거나 반환하는 요청/응답 규격을 고정합니다.
+- `adapter`: 외부 장비 payload를 대시보드 내부에서 쓰는 형태로 변환합니다.
+- 라이다 PC처럼 외부 데이터가 조금씩 바뀔 수 있는 연동은 adapter에 변환 책임을 둡니다.
+- `wrongway` 실제 저장 흐름에서 쓰는 라이다 HTTP adapter는 `domains/wrongway/adapters`에 둡니다.
+- `external-ingest`는 현장 진단, mock 수신, 통합제어보드 패킷 확인처럼 DB 저장 전 수신 상태를 확인하는 용도로 둡니다.
 
 ## Prisma 기준
 

--- a/docs/conventions/project-structure.md
+++ b/docs/conventions/project-structure.md
@@ -111,6 +111,12 @@ dashboard/server
 
 향후 DB, 인증, 사용자 관리가 확정되면 `prisma`, `auth`, `users` 같은 도메인을 추가합니다.
 
+라이다 연동 도메인 기준:
+
+- `domains/wrongway`: `/api/wrongway` 수신, DB 저장, 중복 처리, 테스트 payload API를 담당합니다.
+- `domains/wrongway/adapters`: 라이다 PC HTTP payload를 내부 이벤트 형태로 변환합니다.
+- `domains/external-ingest`: 현장 진단용 mock 수신, 최근 수신 상태 확인, 통합제어보드 패킷 테스트를 담당합니다.
+
 ## 데모/AI 서버 기준
 
 `dashboard/demo-server`는 실제 라이다 PC가 아닌 영상 기반 데모 감지 서버입니다.

--- a/docs/specs/lidar-dashboard-payload.md
+++ b/docs/specs/lidar-dashboard-payload.md
@@ -2,6 +2,17 @@
 
 이 문서는 라이다 PC가 대시보드 백엔드로 전송하는 HTTP JSON 데이터의 현재 개발 기준입니다.
 
+## 코드 처리 위치
+
+- 실제 수신 API: `POST /api/wrongway`
+- 수신 도메인: `dashboard/server/src/domains/wrongway`
+- 변환 adapter: `dashboard/server/src/domains/wrongway/adapters/lidarHttp.adapter.js`
+- 응답 DTO: `dashboard/server/src/domains/wrongway/wrongway.dto.js`
+- 처리 service: `dashboard/server/src/domains/wrongway/wrongway.service.js`
+
+현재 라이다 payload는 외부 장비에서 들어오는 값이므로, controller에서 바로 DB에 저장하지 않습니다.
+adapter가 외부 필드명을 내부 이벤트 필드로 정리하고, service가 `VehicleTrack` 갱신과 `TrafficEvent` 저장 여부를 결정합니다.
+
 ## 기본 연동 정보
 
 - 방향: 라이다 PC -> 대시보드 백엔드


### PR DESCRIPTION
## 작업 내용

- 라이다 HTTP payload adapter 위치를 `external-ingest`에서 `wrongway/adapters`로 이동
- `/api/wrongway` 실제 저장 흐름에서 사용하는 adapter 책임을 wrongway 도메인 안으로 정리
- `external-ingest`는 현장 진단, mock 수신, 통합제어보드 패킷 확인 용도로 역할 분리
- DTO와 adapter 역할 기준 문서화
- 라이다 payload 규격 문서에 실제 처리 파일 위치 추가

## 검증

- `node --check dashboard/server/src/domains/wrongway/adapters/lidarHttp.adapter.js`
- `node --check dashboard/server/src/domains/wrongway/wrongway.service.js`
- `node --check dashboard/server/src/domains/external-ingest/externalIngest.service.js`
- `npm run check:server`
- wrongway/external-ingest service require 로딩 확인